### PR TITLE
FIX: rewritten lib.tools_qgis.gqis_get_layer_source due to parsing er…

### DIFF
--- a/lib/tools_qgis.py
+++ b/lib/tools_qgis.py
@@ -111,7 +111,7 @@ def qgis_get_layer_source(layer):
     uri = layer.dataProvider().dataSourceUri()
 
     # Initialize variables
-    layer_source = {'db': None, 'schema': None, 'table': None,
+    layer_source = {'db': None, 'schema': None, 'table': None, 'service': None,
                     'host': None, 'port': None, 'user': None, 'password': None, 'sslmode': None}
 
     # split with quoted substrings preservation


### PR DESCRIPTION
…rors in previous version.

On QGIS 3.4 worked fine, but we noticed that in QGIS 3.12+ layer.dataProvider().dataSourceUri() returns slightly different URI strings and causes parsing errors.