### PR TITLE
feat(ci): Giswater network E2E + satellite pgTAP

### DIFF
--- a/.github/workflows/e2e-giswater.yml
+++ b/.github/workflows/e2e-giswater.yml
@@ -1,4 +1,4 @@
-name: E2E Giswater (reusable)
+name: 🌊 E2E Giswater (reusable)
 
 on:
   workflow_call:

--- a/.github/workflows/e2e-giswater.yml
+++ b/.github/workflows/e2e-giswater.yml
@@ -1,0 +1,68 @@
+name: E2E Giswater (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      scenario:
+        description: "E2E scenario to run"
+        required: false
+        type: string
+        default: update_all
+      pg_version:
+        description: "PostgreSQL major version"
+        required: false
+        type: string
+        default: "18"
+      satellites:
+        description: "Comma-separated addon kinds"
+        required: false
+        type: string
+        default: "utils,cibs"
+      parent_profile:
+        description: "ws/ud create profile for network scenarios"
+        required: false
+        type: string
+        default: "empty"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      PG_MAJOR: ${{ inputs.pg_version }}
+      POSTGIS_VERSION: ${{ inputs.pg_version == '18' && '3.6' || '3.5' }}
+      SATELLITES: ${{ inputs.satellites }}
+      PARENT_PROFILE: ${{ inputs.parent_profile }}
+      GW_VERBOSE: "1"
+      GW_TIMING: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Show scenario
+        run: |
+          echo "E2E scenario=${{ inputs.scenario }} PG=${{ inputs.pg_version }}"
+          echo "SATELLITES=${{ inputs.satellites }} PARENT_PROFILE=${{ inputs.parent_profile }}"
+
+      - name: Build Docker images
+        working-directory: dbmodel
+        run: docker compose -f docker-compose.test.yml build --quiet postgres runner
+
+      - name: Start Postgres
+        working-directory: dbmodel
+        run: docker compose -f docker-compose.test.yml up -d postgres --wait
+
+      - name: Run E2E (${{ inputs.scenario }})
+        working-directory: dbmodel
+        run: |
+          chmod +x test/*.sh ../scripts/*.sh
+          docker compose -f docker-compose.test.yml run --rm -T runner \
+            bash /workspace/dbmodel/test/e2e_inner.sh "${{ inputs.scenario }}"
+
+      - name: Stop Postgres
+        if: always()
+        working-directory: dbmodel
+        run: docker compose -f docker-compose.test.yml down

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -5,7 +5,14 @@ on:
     types: [published]
 
 jobs:
+  e2e:
+    uses: ./.github/workflows/e2e-giswater.yml
+    with:
+      scenario: update_all
+      pg_version: "18"
+
   publish:
+    needs: [e2e]
     runs-on: ubuntu-latest
     if: startsWith(github.event.release.tag_name, 'cli-v')
     environment: pypi

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -5,7 +5,14 @@ on:
     types: [published]
 
 jobs:
+  e2e:
+    uses: ./.github/workflows/e2e-giswater.yml
+    with:
+      scenario: update_all
+      pg_version: "18"
+
   release:
+    needs: [e2e]
     runs-on: ubuntu-latest
     if: startsWith(github.event.release.tag_name, 'v')
     steps:

--- a/.github/workflows/test-network-e2e.yml
+++ b/.github/workflows/test-network-e2e.yml
@@ -1,0 +1,112 @@
+name: Network E2E (Giswater)
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "profiles | addons | update_isolated | update_network | update_all | satellites"
+        required: false
+        default: "update_all"
+      satellites:
+        description: "Addon kinds (comma-separated)"
+        required: false
+        default: "utils,cibs"
+      parent_profile:
+        description: "Parent ws/ud profile for network scenarios"
+        required: false
+        default: "empty"
+      pg_version:
+        description: "PostgreSQL major version"
+        required: false
+        default: "18"
+      mode:
+        description: "e2e | pgtap_utils | pgtap_cibs | pgtap_network_ws | pgtap_network_ud | pgtap_all"
+        required: false
+        default: "e2e"
+  push:
+    tags:
+      - "v*"
+      - "cli-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    if: github.event_name == 'push' || inputs.mode == 'e2e' || inputs.mode == ''
+    uses: ./.github/workflows/e2e-giswater.yml
+    with:
+      scenario: ${{ github.event_name == 'workflow_dispatch' && inputs.scenario || 'update_all' }}
+      pg_version: ${{ github.event_name == 'workflow_dispatch' && inputs.pg_version || '18' }}
+      satellites: ${{ github.event_name == 'workflow_dispatch' && inputs.satellites || 'utils,cibs' }}
+      parent_profile: ${{ github.event_name == 'workflow_dispatch' && inputs.parent_profile || 'empty' }}
+
+  pgtap-utils:
+    if: github.event_name == 'workflow_dispatch' && (inputs.mode == 'pgtap_utils' || inputs.mode == 'pgtap_all')
+    runs-on: ubuntu-latest
+    env:
+      PG_MAJOR: ${{ inputs.pg_version }}
+      POSTGIS_VERSION: ${{ inputs.pg_version == '18' && '3.6' || '3.5' }}
+    steps:
+      - uses: actions/checkout@v6
+      - working-directory: dbmodel
+        run: |
+          chmod +x test/*.sh ../scripts/*.sh
+          docker compose -f docker-compose.test.yml build --quiet postgres runner
+          docker compose -f docker-compose.test.yml up -d postgres --wait
+          docker compose -f docker-compose.test.yml run --rm -T runner \
+            bash /workspace/dbmodel/test/e2e_inner.sh pgtap_addon utils
+          docker compose -f docker-compose.test.yml down
+
+  pgtap-cibs:
+    if: github.event_name == 'workflow_dispatch' && (inputs.mode == 'pgtap_cibs' || inputs.mode == 'pgtap_all')
+    runs-on: ubuntu-latest
+    env:
+      PG_MAJOR: ${{ inputs.pg_version }}
+      POSTGIS_VERSION: ${{ inputs.pg_version == '18' && '3.6' || '3.5' }}
+    steps:
+      - uses: actions/checkout@v6
+      - working-directory: dbmodel
+        run: |
+          chmod +x test/*.sh ../scripts/*.sh
+          docker compose -f docker-compose.test.yml build --quiet postgres runner
+          docker compose -f docker-compose.test.yml up -d postgres --wait
+          docker compose -f docker-compose.test.yml run --rm -T runner \
+            bash /workspace/dbmodel/test/e2e_inner.sh pgtap_addon cibs
+          docker compose -f docker-compose.test.yml down
+
+  pgtap-network-ws:
+    if: github.event_name == 'workflow_dispatch' && (inputs.mode == 'pgtap_network_ws' || inputs.mode == 'pgtap_all')
+    runs-on: ubuntu-latest
+    env:
+      PG_MAJOR: ${{ inputs.pg_version }}
+      POSTGIS_VERSION: ${{ inputs.pg_version == '18' && '3.6' || '3.5' }}
+      PARENT_PROFILE: ${{ inputs.parent_profile }}
+    steps:
+      - uses: actions/checkout@v6
+      - working-directory: dbmodel
+        run: |
+          chmod +x test/*.sh ../scripts/*.sh
+          docker compose -f docker-compose.test.yml build --quiet postgres runner
+          docker compose -f docker-compose.test.yml up -d postgres --wait
+          GW_PARENT_PROFILE="${PARENT_PROFILE}" docker compose -f docker-compose.test.yml run --rm -T runner \
+            bash /workspace/dbmodel/test/e2e_inner.sh pgtap_network network_ws
+          docker compose -f docker-compose.test.yml down
+
+  pgtap-network-ud:
+    if: github.event_name == 'workflow_dispatch' && (inputs.mode == 'pgtap_network_ud' || inputs.mode == 'pgtap_all')
+    runs-on: ubuntu-latest
+    env:
+      PG_MAJOR: ${{ inputs.pg_version }}
+      POSTGIS_VERSION: ${{ inputs.pg_version == '18' && '3.6' || '3.5' }}
+      PARENT_PROFILE: ${{ inputs.parent_profile }}
+    steps:
+      - uses: actions/checkout@v6
+      - working-directory: dbmodel
+        run: |
+          chmod +x test/*.sh ../scripts/*.sh
+          docker compose -f docker-compose.test.yml build --quiet postgres runner
+          docker compose -f docker-compose.test.yml up -d postgres --wait
+          GW_PARENT_PROFILE="${PARENT_PROFILE}" docker compose -f docker-compose.test.yml run --rm -T runner \
+            bash /workspace/dbmodel/test/e2e_inner.sh pgtap_network network_ud
+          docker compose -f docker-compose.test.yml down

--- a/.github/workflows/test-network-e2e.yml
+++ b/.github/workflows/test-network-e2e.yml
@@ -1,4 +1,4 @@
-name: Network E2E (Giswater)
+name: 🌊 Network E2E (Giswater)
 
 on:
   workflow_dispatch:

--- a/dbmodel/README.md
+++ b/dbmodel/README.md
@@ -278,6 +278,18 @@ PG_MAJOR=18 ./dbmodel/test/run_tests.sh ud
 
 `PG_MAJOR=18` uses PostGIS **3.6**; 16 and 17 use **3.5**.
 
+### Network E2E and satellite pgTAP
+
+CLI lifecycle tests (profiles, upgrades, addon integration, lockstep network) and optional satellite pgTAP:
+
+```bash
+./dbmodel/test/run_e2e.sh update_all       # release gate suite
+./dbmodel/test/run_satellite_tests.sh cibs # pgTAP on cibs schema
+./dbmodel/test/run_satellite_tests.sh network_ws
+```
+
+See [giswater_admin README — Network E2E](../giswater_admin/README.md#network-e2e-optional--release-gate).
+
 ### Environment variables
 
 | Variable | Default | Effect |

--- a/dbmodel/README.md
+++ b/dbmodel/README.md
@@ -280,7 +280,7 @@ PG_MAJOR=18 ./dbmodel/test/run_tests.sh ud
 
 ### Network E2E and satellite pgTAP
 
-CLI lifecycle tests (profiles, upgrades, addon integration, lockstep network) and optional satellite pgTAP:
+CLI lifecycle tests (release gate: isolated upgrade + network lockstep; optional profiles/addons) and satellite pgTAP:
 
 ```bash
 ./dbmodel/test/run_e2e.sh update_all       # release gate suite

--- a/dbmodel/test/_env_inner.sh
+++ b/dbmodel/test/_env_inner.sh
@@ -3,7 +3,16 @@
 set -euo pipefail
 
 PROJECT="${1:-${PROJECT:?set PROJECT or pass as first argument}}"
-SCHEMA="${PROJECT}_40"
+case "${PROJECT}" in
+  ws|ud) SCHEMA="${PROJECT}_40" ;;
+  utils|cibs) SCHEMA="${PROJECT}" ;;
+  network_ws) SCHEMA="ws_40" ;;
+  network_ud) SCHEMA="ud_40" ;;
+  *)
+    echo "error: unknown PROJECT=${PROJECT} (ws|ud|utils|cibs|network_ws|network_ud)" >&2
+    exit 1
+    ;;
+esac
 TEST_GROUPS="${TEST_GROUPS:-all}"
 PG_PROVE_JOBS="${PG_PROVE_JOBS:-4}"
 GW_CONN="${GW_CONN:-postgresql://postgres:postgres@127.0.0.1:5432/gw_db}"

--- a/dbmodel/test/bootstrap_addon_inner.sh
+++ b/dbmodel/test/bootstrap_addon_inner.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bootstrap standalone addon schema for pgTAP (utils or cibs).
+set -euo pipefail
+
+# shellcheck source=_env_inner.sh
+_TEST_ROOT="${GW_TEST_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+source "${_TEST_ROOT}/_env_inner.sh" "${1:?Usage: bootstrap_addon_inner.sh utils|cibs}"
+
+export CONN="${GW_CONN}"
+
+gw() {
+  python3 -m giswater_admin "$@" \
+    --dbmodel-path "${DBMODEL_DIR}" \
+    --conn "${GW_CONN}" \
+    ${GW_ADMIN_FLAGS[@]+"${GW_ADMIN_FLAGS[@]}"}
+}
+
+echo "==> giswater_admin db init"
+gw db init --conn "${GW_CONN}" --with-pgtap
+
+echo "==> drop addon schema ${SCHEMA}"
+gw schema addon drop --type "${PROJECT}" --name "${SCHEMA}" --yes --cascade \
+  --conn "${GW_CONN}" >/dev/null 2>&1 || true
+
+echo "==> schema addon create --type ${PROJECT} --name ${SCHEMA}"
+gw schema addon create \
+  --type "${PROJECT}" \
+  --name "${SCHEMA}" \
+  --profile empty \
+  --version "${GW_PLUGIN_VERSION}" \
+  --conn "${GW_CONN}"
+
+echo "==> replace_vars (staging under test/.run/)"
+TEST_STAGING="$(python3 "${SCRIPT_DIR}/replace_vars.py" "${PROJECT}")"
+mkdir -p "$(dirname "${STAGING_MARKER}")"
+echo "${TEST_STAGING}" > "${STAGING_MARKER}"
+echo "==> test staging: ${TEST_STAGING}"

--- a/dbmodel/test/bootstrap_network_inner.sh
+++ b/dbmodel/test/bootstrap_network_inner.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Bootstrap integrated network (ws+ud+utils+cibs) for pgTAP network_* tests.
+set -euo pipefail
+
+# shellcheck source=_env_inner.sh
+_TEST_ROOT="${GW_TEST_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+source "${_TEST_ROOT}/_env_inner.sh" "${1:?Usage: bootstrap_network_inner.sh network_ws|network_ud}"
+
+export CONN="${GW_CONN}"
+export WS="ws_40"
+export UD="ud_40"
+export UTILS="utils"
+export CIBS="cibs"
+export SATELLITES="${SATELLITES:-utils,cibs}"
+export PARENT_PROFILE="${GW_PARENT_PROFILE:-empty}"
+
+gw() {
+  python3 -m giswater_admin "$@" \
+    --dbmodel-path "${DBMODEL_DIR}" \
+    --conn "${GW_CONN}" \
+    ${GW_ADMIN_FLAGS[@]+"${GW_ADMIN_FLAGS[@]}"}
+}
+
+SCRIPTS="${REPO_ROOT}/scripts"
+
+echo "==> db init (pgTAP)"
+gw db init --conn "${GW_CONN}" --with-pgtap
+
+echo "==> drop previous network (if any)"
+SATELLITES="${SATELLITES}" WS="${WS}" UD="${UD}" \
+  bash "${SCRIPTS}/gw_bootstrap_network.sh" --drop >/dev/null 2>&1 || true
+
+echo "==> bootstrap integrated network (profile=${PARENT_PROFILE})"
+SATELLITES="${SATELLITES}" PARENT_PROFILE="${PARENT_PROFILE}" WS="${WS}" UD="${UD}" \
+  bash "${SCRIPTS}/gw_e2e_addons_integrate.sh"
+
+if [[ ",${SATELLITES}," == *",cibs,"* ]]; then
+  psql "${GW_CONN}" -v ON_ERROR_STOP=1 <<SQL
+UPDATE ${WS}.config_param_system SET value = 'true' WHERE parameter = 'admin_cibs_schema';
+UPDATE ${UD}.config_param_system SET value = 'true' WHERE parameter = 'admin_cibs_schema';
+SQL
+fi
+
+echo "==> replace_vars (staging under test/.run/)"
+TEST_STAGING="$(python3 "${SCRIPT_DIR}/replace_vars.py" "${PROJECT}")"
+mkdir -p "$(dirname "${STAGING_MARKER}")"
+echo "${TEST_STAGING}" > "${STAGING_MARKER}"
+echo "==> test staging: ${TEST_STAGING}"

--- a/dbmodel/test/cibs/schema/tables/test_schema_cat_hydrometer.sql
+++ b/dbmodel/test/cibs/schema/tables/test_schema_cat_hydrometer.sql
@@ -1,0 +1,22 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(3);
+
+SELECT has_table('cat_hydrometer'::name, 'Table cibs.cat_hydrometer should exist');
+SELECT has_table('hydrometer_period'::name, 'Table cibs.hydrometer_period should exist');
+SELECT col_type_is('hydrometer', 'hydrometer_id', 'int4', 'Column hydrometer_id should be int4');
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/cibs/schema/tables/test_schema_sys_version.sql
+++ b/dbmodel/test/cibs/schema/tables/test_schema_sys_version.sql
@@ -1,0 +1,21 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(2);
+
+SELECT has_table('sys_version'::name, 'Table cibs.sys_version should exist');
+SELECT has_table('hydrometer'::name, 'Table cibs.hydrometer should exist');
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/e2e_inner.sh
+++ b/dbmodel/test/e2e_inner.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Docker/CI E2E dispatcher (sources _env_inner.sh, gw shim, runs scripts/*).
+# Usage: e2e_inner.sh <scenario>
+#   profiles | addons | update_isolated | update_network | update_all | satellites
+set -euo pipefail
+
+SCENARIO="${1:?Usage: e2e_inner.sh profiles|addons|update_isolated|update_network|update_all|satellites}"
+
+_TEST_ROOT="${GW_TEST_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+# shellcheck source=_env_inner.sh
+source "${_TEST_ROOT}/_env_inner.sh" ws
+
+export CONN="${GW_CONN}"
+export GW_E2E_DBMODEL="${DBMODEL_DIR}"
+export SATELLITES="${SATELLITES:-utils,cibs}"
+export PARENT_PROFILE="${PARENT_PROFILE:-empty}"
+export E2E_TYPES="${E2E_TYPES:-ws,ud}"
+export E2E_PROFILES="${E2E_PROFILES:-empty,sample,inventory}"
+
+# shellcheck source=../../scripts/gw_e2e_common.sh
+source "${REPO_ROOT}/scripts/gw_e2e_common.sh"
+gw_e2e_setup_gw "${REPO_ROOT}"
+
+export GW_E2E_DBMODEL="${GW_E2E_DBMODEL:-${REPO_ROOT}/dbmodel}"
+
+gw() {
+  python3 -m giswater_admin "$@" \
+    --dbmodel-path "${DBMODEL_DIR}" \
+    --conn "${GW_CONN}" \
+    ${GW_ADMIN_FLAGS[@]+"${GW_ADMIN_FLAGS[@]}"}
+}
+
+SCRIPTS="${REPO_ROOT}/scripts"
+
+case "${SCENARIO}" in
+  profiles)
+    bash "${SCRIPTS}/gw_e2e_profiles.sh"
+    ;;
+  addons)
+    bash "${SCRIPTS}/gw_e2e_addons_integrate.sh"
+    ;;
+  update_isolated)
+    bash "${SCRIPTS}/gw_e2e_update_isolated.sh"
+    ;;
+  update_network)
+    bash "${SCRIPTS}/gw_e2e_network_update.sh"
+    ;;
+  update_all)
+    bash "${SCRIPTS}/gw_e2e_update_all.sh"
+    ;;
+  satellites)
+    bash "${SCRIPTS}/gw_e2e_satellites.sh"
+    ;;
+  pgtap_addon)
+    bash "${_TEST_ROOT}/bootstrap_addon_inner.sh" "${2:?utils|cibs}"
+    bash "${_TEST_ROOT}/prove_inner.sh" "${2}"
+    ;;
+  pgtap_network)
+    bash "${_TEST_ROOT}/bootstrap_network_inner.sh" "${2:?network_ws|network_ud}"
+    bash "${_TEST_ROOT}/prove_inner.sh" "${2}"
+    ;;
+  *)
+    echo "unknown scenario: ${SCENARIO}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${GW_E2E_DROP:-}" == "1" && "${SCENARIO}" != "update_all" ]]; then
+  SATELLITES="${SATELLITES}" bash "${SCRIPTS}/gw_bootstrap_network.sh" --drop || true
+fi

--- a/dbmodel/test/e2e_versions.py
+++ b/dbmodel/test/e2e_versions.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Resolve PLUGIN_VER (create) and TARGET_VER (upgrade) for E2E update tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _collect_versions(root: str) -> list[tuple[int, int, int]]:
+    found: list[tuple[int, int, int]] = []
+    if not os.path.isdir(root):
+        return found
+    for major_name in os.listdir(root):
+        major_path = os.path.join(root, major_name)
+        if not (major_name.isdigit() and os.path.isdir(major_path)):
+            continue
+        for minor_name in os.listdir(major_path):
+            minor_path = os.path.join(major_path, minor_name)
+            if not (minor_name.isdigit() and os.path.isdir(minor_path)):
+                continue
+            for patch_name in os.listdir(minor_path):
+                patch_path = os.path.join(minor_path, patch_name)
+                if not (patch_name.isdigit() and os.path.isdir(patch_path)):
+                    continue
+                patch_sql = os.path.join(patch_path, "patch.sql")
+                if os.path.isfile(patch_sql):
+                    found.append((int(major_name), int(minor_name), int(patch_name)))
+    return found
+
+
+def _fmt(v: tuple[int, int, int]) -> str:
+    return f"{v[0]}.{v[1]}.{v[2]}"
+
+
+def main() -> int:
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    dbmodel = os.path.join(test_dir, "..")
+    roots = [
+        os.path.join(dbmodel, "schemas", "main", "common", "updates"),
+        os.path.join(dbmodel, "schemas", "main", "ws", "updates"),
+        os.path.join(dbmodel, "schemas", "main", "ud", "updates"),
+    ]
+    versions: set[tuple[int, int, int]] = set()
+    for root in roots:
+        for item in _collect_versions(root):
+            versions.add(item)
+    ordered = sorted(versions)
+    if len(ordered) < 2:
+        print(
+            "error: need at least two semver patches under main/*/updates for E2E upgrades",
+            file=sys.stderr,
+        )
+        return 1
+
+    target = ordered[-1]
+    source = ordered[-2]
+    print(f"TARGET_VER={_fmt(target)}")
+    print(f"PLUGIN_VER={_fmt(source)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dbmodel/test/network/ud/schema/tables/test_schema_admin_cibs_flag.sql
+++ b/dbmodel/test/network/ud/schema/tables/test_schema_admin_cibs_flag.sql
@@ -1,0 +1,24 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(1);
+
+SELECT is(
+    (SELECT value FROM config_param_system WHERE parameter = 'admin_cibs_schema'),
+    'true',
+    'admin_cibs_schema flag should be enabled after integration'
+);
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/network/ud/schema/views/test_schema_v_hydrometer.sql
+++ b/dbmodel/test/network/ud/schema/views/test_schema_v_hydrometer.sql
@@ -1,0 +1,26 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(2);
+
+SELECT has_view('v_hydrometer'::name, 'View v_hydrometer should exist after cibs integration');
+SELECT is(
+    (SELECT COUNT(*)::int FROM information_schema.tables
+     WHERE table_schema = 'SCHEMA_NAME' AND table_name = 'ext_hydrometer'),
+    0,
+    'Local ext_hydrometer table should be replaced by cibs integration'
+);
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/network/ws/schema/tables/test_schema_admin_cibs_flag.sql
+++ b/dbmodel/test/network/ws/schema/tables/test_schema_admin_cibs_flag.sql
@@ -1,0 +1,24 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(1);
+
+SELECT is(
+    (SELECT value FROM config_param_system WHERE parameter = 'admin_cibs_schema'),
+    'true',
+    'admin_cibs_schema flag should be enabled after integration'
+);
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/network/ws/schema/views/test_schema_v_hydrometer.sql
+++ b/dbmodel/test/network/ws/schema/views/test_schema_v_hydrometer.sql
@@ -1,0 +1,26 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(2);
+
+SELECT has_view('v_hydrometer'::name, 'View v_hydrometer should exist after cibs integration');
+SELECT is(
+    (SELECT COUNT(*)::int FROM information_schema.tables
+     WHERE table_schema = 'SCHEMA_NAME' AND table_name = 'ext_hydrometer'),
+    0,
+    'Local ext_hydrometer table should be replaced by cibs integration'
+);
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/replace_vars.py
+++ b/dbmodel/test/replace_vars.py
@@ -8,6 +8,21 @@ import sys
 
 STAGING_DIRNAME = ".run"
 
+PROJECT_SCHEMA = {
+    "ws": "ws_40",
+    "ud": "ud_40",
+    "utils": "utils",
+    "cibs": "cibs",
+    "network_ws": "ws_40",
+    "network_ud": "ud_40",
+}
+
+
+SOURCE_TREE = {
+    "network_ws": "network/ws",
+    "network_ud": "network/ud",
+}
+
 
 def replace_vars_in_file(file_path: str, replacements: dict) -> None:
     with open(file_path, encoding="utf-8") as file:
@@ -20,7 +35,8 @@ def replace_vars_in_file(file_path: str, replacements: dict) -> None:
 
 def prepare_staging(project_type: str) -> str:
     test_dir = os.path.dirname(os.path.abspath(__file__))
-    source_root = os.path.join(test_dir, project_type)
+    source_name = SOURCE_TREE.get(project_type, project_type)
+    source_root = os.path.join(test_dir, source_name)
     if not os.path.isdir(source_root):
         raise SystemExit(f"Missing test tree: {source_root}")
 
@@ -29,9 +45,11 @@ def prepare_staging(project_type: str) -> str:
         shutil.rmtree(staging_root)
     shutil.copytree(source_root, staging_root)
 
+    schema_name = PROJECT_SCHEMA.get(project_type, f"{project_type}_40")
     replacements = {
-        "SCHEMA_NAME": f"{project_type}_40",
+        "SCHEMA_NAME": schema_name,
         "SRID_VALUE": "25831",
+        "SATELLITE_SCHEMA": "cibs",
     }
     for root, _dirs, files in os.walk(staging_root):
         for name in files:
@@ -48,6 +66,6 @@ def main(project_type: str) -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python replace_vars.py <ws|ud>")
+        print("Usage: python replace_vars.py <ws|ud|utils|cibs|network_ws|network_ud>")
         sys.exit(1)
     main(sys.argv[1])

--- a/dbmodel/test/run_e2e.sh
+++ b/dbmodel/test/run_e2e.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Host orchestrator: Postgres in Docker, E2E scenarios in runner.
+# Usage: ./test/run_e2e.sh [scenario]
+#   scenario: profiles|addons|update_isolated|update_network|update_all|satellites (default: update_all)
+#   PG_MAJOR=16|17|18
+#   SATELLITES=utils,cibs
+#   PARENT_PROFILE=empty|sample|inventory
+#   GW_CLEAN=1
+set -euo pipefail
+
+SCENARIO="${1:-update_all}"
+PG_MAJOR="${PG_MAJOR:-18}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DBMODEL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+case "${PG_MAJOR}" in
+  18) POSTGIS_VERSION="${POSTGIS_VERSION:-3.6}" ;;
+  *)  POSTGIS_VERSION="${POSTGIS_VERSION:-3.5}" ;;
+esac
+
+export PG_MAJOR POSTGIS_VERSION
+export SATELLITES="${SATELLITES:-utils,cibs}"
+export PARENT_PROFILE="${PARENT_PROFILE:-empty}"
+export GW_VERBOSE="${GW_VERBOSE:-}" GW_DEBUG="${GW_DEBUG:-}" GW_TIMING="${GW_TIMING:-}"
+export GW_ADMIN_FLAGS="${GW_ADMIN_FLAGS:-}"
+
+cd "${DBMODEL_DIR}"
+chmod +x "${SCRIPT_DIR}"/*.sh
+chmod +x "${DBMODEL_DIR}/../scripts"/*.sh 2>/dev/null || true
+
+if [[ "${GW_COMPOSE:-}" == podman ]]; then
+  COMPOSE=(podman compose)
+elif [[ "${GW_COMPOSE:-}" == docker ]]; then
+  COMPOSE=(docker compose)
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1 \
+    && ! docker version 2>/dev/null | grep -q 'Podman Engine'; then
+  COMPOSE=(docker compose)
+elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+  COMPOSE=(podman compose)
+else
+  echo "ERROR: need docker compose or podman compose" >&2
+  exit 1
+fi
+
+compose() { "${COMPOSE[@]}" -f docker-compose.test.yml "$@"; }
+
+echo "==> E2E scenario=${SCENARIO} PostgreSQL ${PG_MAJOR} (${COMPOSE[*]})"
+compose build postgres runner
+
+echo "==> starting postgres..."
+if compose up --help 2>&1 | grep -qE '(^|[[:space:]])--wait([[:space:],]|$)'; then
+  compose up -d postgres --wait
+else
+  compose up -d postgres
+  for i in $(seq 1 120); do
+    compose ps 2>/dev/null | grep -qE '\(healthy\)' && break
+    if [[ "${i}" -eq 120 ]]; then
+      echo "ERROR: postgres not healthy after 120s" >&2
+      compose ps >&2 || true
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+EXIT_CODE=0
+if ! compose run --rm -T runner bash /workspace/dbmodel/test/e2e_inner.sh "${SCENARIO}"; then
+  EXIT_CODE=$?
+fi
+
+if [[ -n "${GW_CLEAN:-}" ]]; then
+  compose rm -sfv postgres >/dev/null 2>&1 || true
+else
+  compose stop postgres >/dev/null 2>&1 || true
+fi
+
+exit "${EXIT_CODE}"

--- a/dbmodel/test/run_satellite_tests.sh
+++ b/dbmodel/test/run_satellite_tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Host orchestrator for satellite pgTAP (standalone or integrated network).
+# Usage: ./test/run_satellite_tests.sh utils|cibs|network_ws|network_ud
+set -euo pipefail
+
+PROJECT="${1:?Usage: $0 utils|cibs|network_ws|network_ud}"
+PG_MAJOR="${PG_MAJOR:-18}"
+TEST_GROUPS="${TEST_GROUPS:-schema}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DBMODEL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+case "${PG_MAJOR}" in
+  18) POSTGIS_VERSION="${POSTGIS_VERSION:-3.6}" ;;
+  *)  POSTGIS_VERSION="${POSTGIS_VERSION:-3.5}" ;;
+esac
+
+export PG_MAJOR POSTGIS_VERSION TEST_GROUPS
+export SATELLITES="${SATELLITES:-utils,cibs}"
+export PARENT_PROFILE="${PARENT_PROFILE:-empty}"
+
+cd "${DBMODEL_DIR}"
+chmod +x "${SCRIPT_DIR}"/*.sh
+chmod +x "${DBMODEL_DIR}/../scripts"/*.sh 2>/dev/null || true
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+  COMPOSE=(podman compose)
+else
+  echo "ERROR: need docker compose or podman compose" >&2
+  exit 1
+fi
+
+compose() { "${COMPOSE[@]}" -f docker-compose.test.yml "$@"; }
+
+compose build postgres runner
+compose up -d postgres --wait 2>/dev/null || compose up -d postgres
+
+EXIT_CODE=0
+case "${PROJECT}" in
+  utils|cibs)
+    compose run --rm -T runner bash /workspace/dbmodel/test/e2e_inner.sh pgtap_addon "${PROJECT}" || EXIT_CODE=$?
+    ;;
+  network_ws|network_ud)
+    compose run --rm -T runner bash /workspace/dbmodel/test/e2e_inner.sh pgtap_network "${PROJECT}" || EXIT_CODE=$?
+    ;;
+  *)
+    echo "unknown project ${PROJECT}" >&2
+    exit 1
+    ;;
+esac
+
+compose stop postgres >/dev/null 2>&1 || true
+exit "${EXIT_CODE}"

--- a/dbmodel/test/utils/schema/tables/test_schema_streetaxis.sql
+++ b/dbmodel/test/utils/schema/tables/test_schema_streetaxis.sql
@@ -1,0 +1,21 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(2);
+
+SELECT has_table('streetaxis'::name, 'Table utils.streetaxis should exist');
+SELECT has_table('municipality'::name, 'Table utils.municipality should exist');
+
+SELECT finish();
+
+ROLLBACK;

--- a/dbmodel/test/utils/schema/tables/test_schema_sys_version.sql
+++ b/dbmodel/test/utils/schema/tables/test_schema_sys_version.sql
@@ -1,0 +1,20 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+
+BEGIN;
+
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(1);
+
+SELECT has_table('sys_version'::name, 'Table utils.sys_version should exist');
+
+SELECT finish();
+
+ROLLBACK;

--- a/giswater_admin/README.md
+++ b/giswater_admin/README.md
@@ -283,6 +283,47 @@ gw create --kind ws --schema test --profile empty --check \
   --conn "postgresql://user@127.0.0.1:5432/mydb"
 ```
 
+### Network E2E (optional / release gate)
+
+Full lifecycle tests (profiles, isolated upgrades, addon integration, lockstep network update). **Required before PyPI / plugin deploy** on `cli-v*` and `v*` releases.
+
+**Local (direct, needs Postgres + `CONN`):**
+
+```bash
+export CONN='postgresql://postgres:postgres@127.0.0.1:5432/gw_db'
+chmod +x scripts/gw_e2e_*.sh scripts/gw_bootstrap_network.sh
+
+./scripts/gw_e2e_profiles.sh              # ws/ud × empty|sample|inventory
+./scripts/gw_e2e_update_isolated.sh       # ws + ud solo @ FROM→TO
+SATELLITES=utils,cibs ./scripts/gw_e2e_addons_integrate.sh
+./scripts/gw_e2e_network_update.sh        # guards + lockstep
+./scripts/gw_e2e_update_all.sh            # full release suite
+```
+
+**Local (Docker, same stack as CI):**
+
+```bash
+./dbmodel/test/run_e2e.sh update_all
+./dbmodel/test/run_e2e.sh profiles
+PG_MAJOR=17 ./dbmodel/test/run_e2e.sh update_network
+
+# Satellite pgTAP (phase 2)
+./dbmodel/test/run_satellite_tests.sh utils
+./dbmodel/test/run_satellite_tests.sh network_ws
+```
+
+**CI:** GitHub Actions → *Network E2E (Giswater)* (`workflow_dispatch`) or automatic on tag push (`v*`, `cli-v*`).
+
+| Scenario | Script / input |
+|----------|----------------|
+| `profiles` | ws/ud × empty, sample, inventory |
+| `update_isolated` | `schema main update` on ws and ud alone |
+| `addons` | utils+cibs create + integrate (`SATELLITES` env) |
+| `update_network` | blocked single updates + `network update` |
+| `update_all` | all of the above (release gate) |
+
+Env: `SATELLITES=utils,cibs`, `PARENT_PROFILE=empty|sample|inventory`, `PLUGIN_VER` / `TARGET_VER` (default: last two semver patches).
+
 ---
 
 ## Connection
@@ -576,12 +617,14 @@ gw network update --version 4.16.0 --conn "$CONN" --check
 gw network update --version 4.16.0 --conn "$CONN"
 ```
 
-**E2E smoke** (empty DB, create @ 4.15.0, upgrade @ 4.16.0):
+**E2E smoke** (linked network @ FROM, lockstep upgrade @ TO — see [Network E2E](#network-e2e-optional--release-gate)):
 
 ```bash
 export CONN='postgresql://user@host:port/giswater_admin_cli'
-chmod +x scripts/gw_e2e_satellites.sh scripts/gw_e2e_network_update.sh
+chmod +x scripts/gw_e2e_*.sh scripts/gw_bootstrap_network.sh
 ./scripts/gw_e2e_network_update.sh
+# or full release suite:
+./scripts/gw_e2e_update_all.sh
 ```
 
 Fixtures under `dbmodel/schemas/**/updates/4/16/0/` (`gw_lockstep_*`) validate cross-schema ordering.

--- a/giswater_admin/README.md
+++ b/giswater_admin/README.md
@@ -285,7 +285,7 @@ gw create --kind ws --schema test --profile empty --check \
 
 ### Network E2E (optional / release gate)
 
-Full lifecycle tests (profiles, isolated upgrades, addon integration, lockstep network update). **Required before PyPI / plugin deploy** on `cli-v*` and `v*` releases.
+Release gate E2E (isolated ws/ud upgrades + linked network lockstep update). **Required before PyPI / plugin deploy** on `cli-v*` and `v*` releases. Profile creates and standalone addon integrate run separately (`run_e2e.sh profiles|addons`) or via pgTAP on PR.
 
 **Local (direct, needs Postgres + `CONN`):**
 
@@ -320,7 +320,7 @@ PG_MAJOR=17 ./dbmodel/test/run_e2e.sh update_network
 | `update_isolated` | `schema main update` on ws and ud alone |
 | `addons` | utils+cibs create + integrate (`SATELLITES` env) |
 | `update_network` | blocked single updates + `network update` |
-| `update_all` | all of the above (release gate) |
+| `update_all` | `update_isolated` + `update_network` (release gate) |
 
 Env: `SATELLITES=utils,cibs`, `PARENT_PROFILE=empty|sample|inventory`, `PLUGIN_VER` / `TARGET_VER` (default: last two semver patches).
 

--- a/scripts/gw_bootstrap_network.sh
+++ b/scripts/gw_bootstrap_network.sh
@@ -11,9 +11,12 @@
 #   --drop    drop network + satellite schemas (demo cleanup)
 #
 # Schema names (override via env):
-#   WS=ws UD=ud UTILS=utils CIBS=cibs
+#   WS=ws UD=ud UTILS=utils CIBS=cibs CM=cm AM=am AUDIT=audit
 #
-# Extend satellites: edit SATELLITES_CREATE below (uncomment cm, am, audit when ready).
+# Satellites (comma-separated kinds):
+#   SATELLITES=utils,cibs,cm,am,audit
+# Parent create profile for ws/ud:
+#   PARENT_PROFILE=empty|sample|inventory
 
 set -euo pipefail
 
@@ -22,9 +25,11 @@ WS="${WS:-ws}"
 UD="${UD:-ud}"
 UTILS="${UTILS:-utils}"
 CIBS="${CIBS:-cibs}"
-# CM="${CM:-cm}"
-# AM="${AM:-am}"
-# AUDIT="${AUDIT:-audit}"
+CM="${CM:-cm}"
+AM="${AM:-am}"
+AUDIT="${AUDIT:-audit}"
+PARENT_PROFILE="${PARENT_PROFILE:-empty}"
+SATELLITES="${SATELLITES:-utils,cibs}"
 
 CHECK=""
 DROP=""
@@ -34,54 +39,74 @@ for arg in "$@"; do
     --check) CHECK="--check" ;;
     --drop) DROP=1 ;;
     -h|--help)
-      sed -n '2,16p' "$0"
+      sed -n '2,22p' "$0"
       exit 0
       ;;
     *) echo "Unknown arg: $arg (try --help)" >&2; exit 1 ;;
   esac
 done
 
-# Satellite kinds to create and integrate with each parent (ws, ud).
-# Order matters if you add FK-dependent addons later.
-SATELLITES_CREATE=(
-  utils
-  cibs
-  # cm
-  # am
-  # audit
-)
+IFS=',' read -ra SATELLITES_CREATE <<< "${SATELLITES}"
 
 declare -A SATELLITE_NAME=(
   [utils]="$UTILS"
   [cibs]="$CIBS"
-  # [cm]="$CM"
-  # [am]="$AM"
-  # [audit]="$AUDIT"
+  [cm]="$CM"
+  [am]="$AM"
+  [audit]="$AUDIT"
 )
 
 PARENTS=("$WS" "$UD")
 
-PLUGIN_VER="${PLUGIN_VER:-}"
+if [[ -z "${PLUGIN_VER:-}" ]]; then
+  _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  eval "$(python3 "${_repo_root}/dbmodel/test/e2e_versions.py")"
+  # Create at source version; lockstep/network tests upgrade to TARGET_VER.
+  PLUGIN_VER="${PLUGIN_VER}"
+fi
+
+gw_cmd() {
+  if declare -F gw >/dev/null 2>&1; then
+    gw "$@"
+  elif command -v gw >/dev/null 2>&1; then
+    command gw "$@"
+  else
+    local extra=()
+    if [[ -n "${GW_E2E_DBMODEL:-}" ]]; then
+      extra+=(--dbmodel-path "${GW_E2E_DBMODEL}")
+    elif [[ -n "${DBMODEL_DIR:-}" ]]; then
+      extra+=(--dbmodel-path "${DBMODEL_DIR}")
+    fi
+    python3 -m giswater_admin "$@" "${extra[@]}" \
+      ${GW_ADMIN_FLAGS[@]+"${GW_ADMIN_FLAGS[@]}"}
+  fi
+}
 
 run() {
   echo ""
   echo ">>> gw $*"
-  extra=()
-  if [[ -n "$PLUGIN_VER" ]]; then
-    extra+=(--version "$PLUGIN_VER")
-  fi
-  gw "$@" "${extra[@]}" $CHECK
+  local extra=()
+  case "$1" in
+    schema)
+      if [[ -n "$PLUGIN_VER" ]]; then
+        extra+=(--version "$PLUGIN_VER")
+      fi
+      ;;
+  esac
+  gw_cmd "$@" "${extra[@]}" $CHECK
 }
 
 drop_schemas() {
   echo "=== drop network schemas ==="
-  gw schema main drop --name "$WS" --yes --cascade --conn "$CONN" || true
-  gw schema main drop --name "$UD" --yes --cascade --conn "$CONN" || true
+  gw_cmd schema main drop --name "$WS" --yes --cascade --conn "$CONN" || true
+  gw_cmd schema main drop --name "$UD" --yes --cascade --conn "$CONN" || true
 
   echo "=== drop satellite schemas ==="
   for kind in "${SATELLITES_CREATE[@]}"; do
+    kind="${kind// /}"
+    [[ -z "$kind" ]] && continue
     name="${SATELLITE_NAME[$kind]:-$kind}"
-    gw schema addon drop --type "$kind" --name "$name" --yes --cascade --conn "$CONN" || true
+    gw_cmd schema addon drop --type "$kind" --name "$name" --yes --cascade --conn "$CONN" || true
   done
 
   echo "Dropped $WS $UD and satellites: ${SATELLITES_CREATE[*]}"
@@ -89,21 +114,16 @@ drop_schemas() {
 
 create_satellite() {
   local kind="$1"
+  kind="${kind// /}"
   local name="${SATELLITE_NAME[$kind]:-$kind}"
-  local extra=()
+  local extra=(--name "$name")
 
   case "$kind" in
-    utils|cibs)
-      extra=(--name "$name")
+    cm)
+      extra+=(--profile bootstrap)
       ;;
-    # cm|am)
-    #   extra=(--name "$name" --profile bootstrap)
-    #   ;;
-    # audit)
-    #   extra=(--name "$name" --profile empty)
-    #   ;;
-    *)
-      extra=(--name "$name")
+    audit)
+      extra+=(--profile empty)
       ;;
   esac
 
@@ -113,18 +133,24 @@ create_satellite() {
 integrate_satellite() {
   local kind="$1"
   local parent="$2"
+  kind="${kind// /}"
+
+  # am integrates with ws parent only
+  if [[ "$kind" == "am" && "$parent" != "$WS" ]]; then
+    echo "skip am integrate on ${parent} (ws only)"
+    return 0
+  fi
 
   case "$kind" in
     utils)
       run schema addon integrate --type utils --parent "$parent" --conn "$CONN"
       ;;
+    audit)
+      run schema addon integrate --type audit --parent "$parent" --profile integrate --conn "$CONN"
+      ;;
     cibs|cm|am)
       run schema addon integrate --type "$kind" --parent "$parent" --conn "$CONN"
       ;;
-    # audit uses activate profile after structure exists
-    # audit)
-    #   run schema addon integrate --type audit --parent "$parent" --profile integrate --conn "$CONN"
-    #   ;;
     *)
       run schema addon integrate --type "$kind" --parent "$parent" --conn "$CONN"
       ;;
@@ -139,17 +165,21 @@ fi
 echo "=== 1. PostgreSQL extensions ==="
 run db init --conn "$CONN"
 
-echo "=== 2. Network schemas (ws + ud) ==="
-run schema main create --type ws --name "$WS" --profile empty --conn "$CONN"
-run schema main create --type ud --name "$UD" --profile empty --conn "$CONN"
+echo "=== 2. Network schemas (ws + ud) profile=${PARENT_PROFILE} ==="
+run schema main create --type ws --name "$WS" --profile "$PARENT_PROFILE" --conn "$CONN"
+run schema main create --type ud --name "$UD" --profile "$PARENT_PROFILE" --conn "$CONN"
 
-echo "=== 3. Satellite schemas ==="
+echo "=== 3. Satellite schemas (${SATELLITES}) ==="
 for kind in "${SATELLITES_CREATE[@]}"; do
+  kind="${kind// /}"
+  [[ -z "$kind" ]] && continue
   create_satellite "$kind"
 done
 
 echo "=== 4. Integrate satellites with ws and ud ==="
 for kind in "${SATELLITES_CREATE[@]}"; do
+  kind="${kind// /}"
+  [[ -z "$kind" ]] && continue
   for parent in "${PARENTS[@]}"; do
     integrate_satellite "$kind" "$parent"
   done
@@ -158,11 +188,7 @@ done
 if [[ -z "$CHECK" ]]; then
   echo ""
   echo "=== 5. Network status ==="
-  extra=()
-  if [[ -n "$PLUGIN_VER" ]]; then
-    extra+=(--version "$PLUGIN_VER")
-  fi
-  gw network show "${extra[@]}" --conn "$CONN"
+  gw_cmd network show --conn "$CONN"
 fi
 
 echo ""

--- a/scripts/gw_e2e_addons_integrate.sh
+++ b/scripts/gw_e2e_addons_integrate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# E2E: multi-addon create + integrate + asserts.
+#
+# Usage:
+#   export CONN='postgresql://...'
+#   SATELLITES=utils,cibs ./scripts/gw_e2e_addons_integrate.sh
+#   SATELLITES=utils,cibs,cm,am,audit ./scripts/gw_e2e_addons_integrate.sh
+
+set -euo pipefail
+
+CONN="${CONN:?Set CONN to a postgresql URL}"
+WS="${WS:-ws}"
+UD="${UD:-ud}"
+SATELLITES="${SATELLITES:-utils,cibs}"
+PARENT_PROFILE="${PARENT_PROFILE:-empty}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=gw_e2e_common.sh
+source "${SCRIPT_DIR}/gw_e2e_common.sh"
+
+REPO="$(gw_e2e_repo_root)"
+gw_e2e_setup_gw "${REPO}"
+gw_e2e_resolve_versions
+export GW_E2E_DBMODEL="${GW_E2E_DBMODEL:-${REPO}/dbmodel}"
+
+export WS UD SATELLITES PARENT_PROFILE
+
+run_drop=true
+for arg in "$@"; do
+  case "$arg" in
+    --check|--drop) run_drop=false ;;
+  esac
+done
+if [[ "$run_drop" == true ]]; then
+  SATELLITES="${SATELLITES}" PARENT_PROFILE="${PARENT_PROFILE}" WS="${WS}" UD="${UD}" \
+    "$SCRIPT_DIR/gw_bootstrap_network.sh" --drop >/dev/null 2>&1 || true
+fi
+
+"$SCRIPT_DIR/gw_bootstrap_network.sh" "$@"
+
+for arg in "$@"; do
+  case "$arg" in
+    --check|--drop) exit 0 ;;
+  esac
+done
+
+echo "=== Assert satellite schemas ==="
+IFS=',' read -ra KINDS <<< "${SATELLITES}"
+for kind in "${KINDS[@]}"; do
+  kind="${kind// /}"
+  [[ -z "$kind" ]] && continue
+  schema="${kind}"
+  case "$kind" in
+    utils) schema="${UTILS:-utils}" ;;
+    cibs) schema="${CIBS:-cibs}" ;;
+    cm) schema="${CM:-cm}" ;;
+    am) schema="${AM:-am}" ;;
+    audit) schema="${AUDIT:-audit}" ;;
+  esac
+  psql "$CONN" -v ON_ERROR_STOP=1 -c \
+    "SELECT 1 FROM information_schema.schemata WHERE schema_name = '${schema}'" | grep -q 1
+  gw_e2e_assert_sys_version "$schema" "${PLUGIN_VER}"
+done
+
+echo "=== Post-steps (cibs flags + role permissions) ==="
+if [[ ",${SATELLITES}," == *",cibs,"* ]]; then
+  psql "$CONN" -v ON_ERROR_STOP=1 <<SQL
+SELECT ${WS}.gw_fct_admin_role_permissions();
+UPDATE ${WS}.config_param_system SET value = 'true' WHERE parameter = 'admin_cibs_schema';
+SELECT ${UD}.gw_fct_admin_role_permissions();
+UPDATE ${UD}.config_param_system SET value = 'true' WHERE parameter = 'admin_cibs_schema';
+SQL
+fi
+
+echo "=== Network topology ==="
+gw network show --conn "$CONN"
+
+echo "E2E addons integrate done."

--- a/scripts/gw_e2e_common.sh
+++ b/scripts/gw_e2e_common.sh
@@ -1,0 +1,75 @@
+# Shared helpers for gw E2E scripts (source, do not execute).
+# Requires CONN when running gw/psql helpers.
+
+gw_e2e_repo_root() {
+  local here="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+  here="$(cd "$(dirname "${here}")/.." && pwd)"
+  echo "${here}"
+}
+
+gw_e2e_resolve_versions() {
+  local repo dbmodel
+  repo="$(gw_e2e_repo_root)"
+  dbmodel="${repo}/dbmodel"
+  if [[ -n "${PLUGIN_VER:-}" && -n "${TARGET_VER:-}" ]]; then
+    return 0
+  fi
+  eval "$(python3 "${dbmodel}/test/e2e_versions.py")"
+  export PLUGIN_VER TARGET_VER
+}
+
+gw_e2e_setup_gw() {
+  local repo="${1:?}"
+  export GW_E2E_REPO="${repo}"
+  export GW_E2E_DBMODEL="${repo}/dbmodel"
+  export CONN="${CONN:-${GW_CONN:-}}"
+  export PYTHONPATH="${repo}${PYTHONPATH:+:${PYTHONPATH}}"
+  export PGPASSWORD="${PGPASSWORD:-postgres}"
+
+  gw() {
+    python3 -m giswater_admin "$@" \
+      --dbmodel-path "${GW_E2E_DBMODEL}" \
+      ${GW_ADMIN_FLAGS[@]+"${GW_ADMIN_FLAGS[@]}"}
+  }
+}
+
+gw_e2e_assert_sys_version() {
+  local schema="$1"
+  local expected="$2"
+  local got
+  got="$(psql "$CONN" -tA -v ON_ERROR_STOP=1 \
+    -c "SELECT giswater FROM \"${schema}\".sys_version ORDER BY id DESC LIMIT 1")"
+  if [[ "${got}" != "${expected}" ]]; then
+    echo "assert failed: ${schema}.sys_version expected ${expected}, got ${got}" >&2
+    return 1
+  fi
+  echo "ok: ${schema}.sys_version = ${expected}"
+}
+
+gw_e2e_assert_table_rows() {
+  local schema="$1"
+  local table="$2"
+  local min_rows="${3:-1}"
+  local count
+  count="$(psql "$CONN" -tA -v ON_ERROR_STOP=1 \
+    -c "SELECT COUNT(*) FROM \"${schema}\".\"${table}\"")"
+  if [[ "${count}" -lt "${min_rows}" ]]; then
+    echo "assert failed: ${schema}.${table} expected >= ${min_rows} rows, got ${count}" >&2
+    return 1
+  fi
+  echo "ok: ${schema}.${table} rows=${count}"
+}
+
+gw_e2e_run_guards() {
+  local ws="${WS:-ws}"
+  echo "=== Guard: isolated schema update must fail in linked network ==="
+  if gw schema main update --name "$ws" --conn "$CONN" 2>/dev/null; then
+    echo "expected gw schema main update --name ${ws} to fail" >&2
+    return 1
+  fi
+  if gw schema addon update --type utils --conn "$CONN" 2>/dev/null; then
+    echo "expected gw schema addon update --type utils to fail" >&2
+    return 1
+  fi
+  echo "guard ok (blocked)"
+}

--- a/scripts/gw_e2e_network_update.sh
+++ b/scripts/gw_e2e_network_update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# End-to-end: create linked network @ 4.15.0, then lockstep update to 4.16.0.
+# End-to-end: create linked network @ PLUGIN_VER, guards, lockstep update to TARGET_VER.
 #
 # Usage:
 #   export CONN='postgresql://user@host:port/giswater_admin_cli'
@@ -8,22 +8,28 @@
 set -euo pipefail
 
 CONN="${CONN:?Set CONN to a postgresql URL}"
-PLUGIN_VER="${PLUGIN_VER:-4.15.0}"
-TARGET_VER="${TARGET_VER:-4.16.0}"
 WS="${WS:-ws}"
+SATELLITES="${SATELLITES:-utils,cibs}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=gw_e2e_common.sh
+source "${SCRIPT_DIR}/gw_e2e_common.sh"
+
+REPO="$(gw_e2e_repo_root)"
+gw_e2e_setup_gw "${REPO}"
+gw_e2e_resolve_versions
+
+export WS SATELLITES PLUGIN_VER
+export PARENT_PROFILE="${PARENT_PROFILE:-sample}"
 
 echo "=== 1. Create + link network @ ${PLUGIN_VER} ==="
-PLUGIN_VER="$PLUGIN_VER" ./scripts/gw_e2e_satellites.sh
+PLUGIN_VER="$PLUGIN_VER" "$SCRIPT_DIR/gw_e2e_satellites.sh"
 
 echo "=== 2. Network topology ==="
 gw network show --conn "$CONN"
 
-echo "=== 3. Guard: single update must fail ==="
-if gw schema addon update --type utils --conn "$CONN" 2>/dev/null; then
-  echo "expected gw schema addon update --type utils to fail" >&2
-  exit 1
-fi
-echo "guard ok (blocked)"
+echo "=== 3. Guard checks ==="
+gw_e2e_run_guards
 
 echo "=== 4. Lockstep plan ==="
 gw network update --version "$TARGET_VER" --check --conn "$CONN"
@@ -31,15 +37,11 @@ gw network update --version "$TARGET_VER" --check --conn "$CONN"
 echo "=== 5. Lockstep execute ==="
 gw network update --version "$TARGET_VER" --conn "$CONN"
 
-echo "=== 6. Assert markers ==="
-psql "$CONN" -v ON_ERROR_STOP=1 <<SQL
-SELECT giswater FROM ${WS}.sys_version ORDER BY id DESC LIMIT 1;
-SELECT giswater FROM ud.sys_version ORDER BY id DESC LIMIT 1;
-SELECT giswater FROM utils.sys_version ORDER BY id DESC LIMIT 1;
-SELECT giswater FROM cibs.sys_version ORDER BY id DESC LIMIT 1;
-SELECT value FROM ${WS}.config_param_system WHERE parameter = 'gw_lockstep_ws';
-SELECT target_version FROM utils.gw_lockstep_marker;
-SQL
+echo "=== 6. Assert versions ==="
+gw_e2e_assert_sys_version "$WS" "$TARGET_VER"
+gw_e2e_assert_sys_version "ud" "$TARGET_VER"
+gw_e2e_assert_sys_version "utils" "$TARGET_VER"
+gw_e2e_assert_sys_version "cibs" "$TARGET_VER"
 
 echo "=== 7. Network after update ==="
 gw network show --conn "$CONN"

--- a/scripts/gw_e2e_profiles.sh
+++ b/scripts/gw_e2e_profiles.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# E2E: ws/ud × empty|sample|inventory profile creates.
+#
+# Usage:
+#   export CONN='postgresql://...'
+#   ./scripts/gw_e2e_profiles.sh
+#   E2E_TYPES=ws E2E_PROFILES=empty,sample ./scripts/gw_e2e_profiles.sh
+
+set -euo pipefail
+
+CONN="${CONN:?Set CONN to a postgresql URL}"
+E2E_TYPES="${E2E_TYPES:-ws,ud}"
+E2E_PROFILES="${E2E_PROFILES:-empty,sample,inventory}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=gw_e2e_common.sh
+source "${SCRIPT_DIR}/gw_e2e_common.sh"
+
+REPO="$(gw_e2e_repo_root)"
+gw_e2e_setup_gw "${REPO}"
+
+TARGET_VER="$(python3 "${REPO}/dbmodel/test/plugin_version.py")"
+
+IFS=',' read -ra TYPES <<< "${E2E_TYPES}"
+IFS=',' read -ra PROFILES <<< "${E2E_PROFILES}"
+
+echo "=== db init ==="
+gw db init --conn "$CONN"
+
+for ptype in "${TYPES[@]}"; do
+  for profile in "${PROFILES[@]}"; do
+    schema="e2e_${ptype}_${profile}"
+    echo ""
+    echo "=== create ${ptype} profile=${profile} schema=${schema} ==="
+    gw schema main drop --name "$schema" --yes --cascade --conn "$CONN" >/dev/null 2>&1 || true
+    gw schema main create \
+      --type "$ptype" \
+      --name "$schema" \
+      --profile "$profile" \
+      --srid 25831 \
+      --lang en_US \
+      --version "$TARGET_VER" \
+      --conn "$CONN"
+    gw_e2e_assert_sys_version "$schema" "$TARGET_VER"
+
+    case "${profile}" in
+      sample)
+        if [[ "$ptype" == "ws" ]]; then
+          gw_e2e_assert_table_rows "$schema" node 1
+        else
+          gw_e2e_assert_table_rows "$schema" node 1
+        fi
+        ;;
+      inventory)
+        gw_e2e_assert_table_rows "$schema" node 1
+        ;;
+      empty)
+        ;;
+      *)
+        echo "unknown profile ${profile}" >&2
+        exit 1
+        ;;
+    esac
+
+    gw schema main drop --name "$schema" --yes --cascade --conn "$CONN"
+  done
+done
+
+echo ""
+echo "E2E profiles done."

--- a/scripts/gw_e2e_satellites.sh
+++ b/scripts/gw_e2e_satellites.sh
@@ -19,6 +19,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 bootstrap_args=("$@")
 
+run_drop=true
+for arg in "$@"; do
+  case "$arg" in
+    --check|--drop) run_drop=false ;;
+  esac
+done
+if [[ "$run_drop" == true ]]; then
+  SATELLITES="${SATELLITES:-utils,cibs}" WS="${WS}" UD="${UD}" \
+    "$SCRIPT_DIR/gw_bootstrap_network.sh" --drop >/dev/null 2>&1 || true
+fi
+
 "$SCRIPT_DIR/gw_bootstrap_network.sh" "${bootstrap_args[@]}"
 
 for arg in "$@"; do

--- a/scripts/gw_e2e_update_all.sh
+++ b/scripts/gw_e2e_update_all.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run full E2E suite for release gate (profiles + isolated update + addons + network).
+#
+# Usage:
+#   export CONN='postgresql://...'
+#   ./scripts/gw_e2e_update_all.sh
+
+set -euo pipefail
+
+CONN="${CONN:?Set CONN to a postgresql URL}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "########## E2E update_all: profiles ##########"
+"$SCRIPT_DIR/gw_e2e_profiles.sh"
+
+echo ""
+echo "########## E2E update_all: update_isolated ##########"
+"$SCRIPT_DIR/gw_e2e_update_isolated.sh"
+
+echo ""
+echo "########## E2E update_all: addons ##########"
+SATELLITES="${SATELLITES:-utils,cibs}" "$SCRIPT_DIR/gw_e2e_addons_integrate.sh"
+
+echo ""
+echo "########## E2E update_all: cleanup network before lockstep ##########"
+SATELLITES="${SATELLITES:-utils,cibs}" "$SCRIPT_DIR/gw_bootstrap_network.sh" --drop
+
+echo ""
+echo "########## E2E update_all: update_network ##########"
+"$SCRIPT_DIR/gw_e2e_network_update.sh"
+
+echo ""
+echo "E2E update_all passed."

--- a/scripts/gw_e2e_update_all.sh
+++ b/scripts/gw_e2e_update_all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Run full E2E suite for release gate (profiles + isolated update + addons + network).
+# Release gate: isolated ws/ud upgrades + linked network lockstep update.
+# Profiles and standalone addon integrate remain as separate scenarios
+# (./dbmodel/test/run_e2e.sh profiles|addons) and pgTAP on PR.
 #
 # Usage:
 #   export CONN='postgresql://...'
@@ -11,20 +13,10 @@ CONN="${CONN:?Set CONN to a postgresql URL}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "########## E2E update_all: profiles ##########"
-"$SCRIPT_DIR/gw_e2e_profiles.sh"
+export PARENT_PROFILE="${PARENT_PROFILE:-empty}"
 
-echo ""
 echo "########## E2E update_all: update_isolated ##########"
 "$SCRIPT_DIR/gw_e2e_update_isolated.sh"
-
-echo ""
-echo "########## E2E update_all: addons ##########"
-SATELLITES="${SATELLITES:-utils,cibs}" "$SCRIPT_DIR/gw_e2e_addons_integrate.sh"
-
-echo ""
-echo "########## E2E update_all: cleanup network before lockstep ##########"
-SATELLITES="${SATELLITES:-utils,cibs}" "$SCRIPT_DIR/gw_bootstrap_network.sh" --drop
 
 echo ""
 echo "########## E2E update_all: update_network ##########"

--- a/scripts/gw_e2e_update_isolated.sh
+++ b/scripts/gw_e2e_update_isolated.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# E2E: isolated ws and ud schema upgrades (no linked network).
+#
+# Usage:
+#   export CONN='postgresql://...'
+#   ./scripts/gw_e2e_update_isolated.sh
+#   PLUGIN_VER=4.14.0 TARGET_VER=4.15.0 ./scripts/gw_e2e_update_isolated.sh
+
+set -euo pipefail
+
+CONN="${CONN:?Set CONN to a postgresql URL}"
+E2E_TYPES="${E2E_TYPES:-ws,ud}"
+E2E_UPDATE_PROFILE="${E2E_UPDATE_PROFILE:-sample}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=gw_e2e_common.sh
+source "${SCRIPT_DIR}/gw_e2e_common.sh"
+
+REPO="$(gw_e2e_repo_root)"
+gw_e2e_setup_gw "${REPO}"
+gw_e2e_resolve_versions
+
+echo "=== db init ==="
+gw db init --conn "$CONN"
+echo "=== upgrade path ${PLUGIN_VER} -> ${TARGET_VER} ==="
+
+IFS=',' read -ra TYPES <<< "${E2E_TYPES}"
+for ptype in "${TYPES[@]}"; do
+  schema="e2e_upd_${ptype}"
+  echo ""
+  echo "=== ${ptype}: create @ ${PLUGIN_VER} ==="
+  gw schema main drop --name "$schema" --yes --cascade --conn "$CONN" >/dev/null 2>&1 || true
+  gw schema main create \
+    --type "$ptype" \
+    --name "$schema" \
+    --profile "$E2E_UPDATE_PROFILE" \
+    --version "$PLUGIN_VER" \
+    --conn "$CONN"
+
+  gw_e2e_assert_sys_version "$schema" "$PLUGIN_VER"
+
+  echo "=== ${ptype}: update -> ${TARGET_VER} ==="
+  gw schema main update --name "$schema" --version "$TARGET_VER" --conn "$CONN"
+  gw_e2e_assert_sys_version "$schema" "$TARGET_VER"
+
+  gw schema main drop --name "$schema" --yes --cascade --conn "$CONN"
+done
+
+echo ""
+echo "E2E update isolated done."


### PR DESCRIPTION
## Summary
- E2E CLI suite: profiles (empty/sample/inventory), isolated ws/ud updates, utils+cibs integration, lockstep `network update`
- Docker harness (`run_e2e.sh`, `e2e_inner.sh`) + reusable workflow `e2e-giswater.yml`
- Release gate: `release-cli.yml` / `release-plugin.yml` require `update_all` before PyPI/SFTP
- pgTAP satellites: standalone `utils`/`cibs` + integrated `network/ws|ud`
- Manual workflow: **Network E2E (Giswater)** (`workflow_dispatch`)

## CI on this PR
- **Auto:** `test-db.yml` (pgTAP ws/ud) — paths under `dbmodel/**`
- **Manual:** Actions → *Network E2E* → Run workflow → branch `feature/e2e-giswater-network`, scenario `update_all` (~4–6 min on GH runners)
- E2E does **not** run on every push/PR by design (release gate + manual only)

## Test plan
- [ ] pgTAP CI green on PR
- [ ] Run `Network E2E` workflow_dispatch with `update_all` on this branch
- [ ] Optional: `mode=pgtap_all` for satellite pgTAP jobs
