### PR TITLE
refactor(scada_graph): recalc one edge on Accept and reject duplicates

### DIFF
--- a/core/shared/scada_graph.py
+++ b/core/shared/scada_graph.py
@@ -11,7 +11,7 @@ from functools import partial
 
 from qgis.PyQt.QtWidgets import QLineEdit
 from qgis.PyQt.sip import isdeleted
-from qgis.core import QgsExpression
+from qgis.core import QgsExpression, QgsFeatureRequest
 from qgis.gui import QgsMapToolEmitPoint
 
 from ..ui.ui_manager import GwScadaGraphUi
@@ -38,6 +38,7 @@ class GwScadaGraph:
         self.layer_node = None
         self._pick_target = None
         self._node_widgets = {}
+        self._graph_layer = None
 
     def run(self):
         """ Open scada graph dialog """
@@ -120,6 +121,14 @@ class GwScadaGraph:
             msg = "object_1 and object_2 must be different."
             tools_qt.show_info_box(msg)
             return None, None
+        sql = (
+            "SELECT edge_id FROM om_scada_graph "
+            f"WHERE object_1 = {int(object_1)} AND object_2 = {int(object_2)} LIMIT 1"
+        )
+        if tools_db.get_row(sql, log_info=False):
+            msg = "Scada graph edge already exists."
+            tools_qt.show_info_box(msg)
+            return None, None
         return int(object_1), int(object_2)
 
     def _set_picked_node(self, target, node_id):
@@ -154,7 +163,8 @@ class GwScadaGraph:
 
         params = f'"object_1":{node1}, "object_2":{node2}'
         body = tools_gw.create_body(extras=f'"parameters":{{{params}}}')
-        json_result = tools_gw.execute_procedure('gw_fct_scada_graph_build', body)
+        json_result = tools_gw.execute_procedure(
+            'gw_fct_scada_graph_build', body, check_function=False, log_sql=False)
         if not json_result or json_result.get('status') != 'Accepted':
             return
 
@@ -166,27 +176,41 @@ class GwScadaGraph:
     def _ensure_graph_layer(self):
         """ Load om_graph layer in QGIS project """
 
+        layer = self._graph_layer
+        if layer is not None and not isdeleted(layer) and layer.isValid():
+            if not tools_qgis.is_layer_visible(layer):
+                tools_qgis.set_layer_visible(layer)
+            return layer
+
         for name in _GRAPH_LAYER_NAMES:
             candidate = tools_qgis.get_layer_by_layername(name, log_info=False)
             if candidate:
-                tools_qgis.set_layer_visible(candidate)
+                self._graph_layer = candidate
+                if not tools_qgis.is_layer_visible(candidate):
+                    tools_qgis.set_layer_visible(candidate)
                 return candidate
         for tablename in _GRAPH_TABLE_NAMES:
             layer = tools_qgis.get_layer_by_tablename(tablename, show_warning_=False)
             if layer:
-                tools_qgis.set_layer_visible(layer)
+                self._graph_layer = layer
+                if not tools_qgis.is_layer_visible(layer):
+                    tools_qgis.set_layer_visible(layer)
                 return layer
         tools_gw.add_layer_database(
             'om_scada_graph', the_geom='the_geom', field_id='edge_id',
             alias='om_graph', group='OM', sub_group='Scada')
         layer = tools_qgis.get_layer_by_layername('om_graph', log_info=False)
         if layer:
-            tools_qgis.set_layer_visible(layer)
+            self._graph_layer = layer
+            if not tools_qgis.is_layer_visible(layer):
+                tools_qgis.set_layer_visible(layer)
             return layer
-        return tools_qgis.get_layer_by_tablename('om_scada_graph', show_warning_=False)
+        layer = tools_qgis.get_layer_by_tablename('om_scada_graph', show_warning_=False)
+        self._graph_layer = layer
+        return layer
 
     def _refresh_graph_on_map(self, edge_id, dialog=None):
-        """ Reload layer, select edge and zoom """
+        """ Reload provider, select the new edge and zoom once """
 
         layer = self._ensure_graph_layer()
         if not layer:
@@ -194,12 +218,20 @@ class GwScadaGraph:
             tools_qgis.show_warning(msg, dialog=dialog)
             return
         layer.dataProvider().reloadData()
-        layer.triggerRepaint()
-        layer.removeSelection()
-        expr_obj = QgsExpression(f'"edge_id" = {edge_id}')
-        tools_qgis.select_features_by_expr(layer, expr_obj)
-        tools_gw.zoom_to_feature_by_id('om_scada_graph', 'edge_id', edge_id)
-        self.canvas.refresh()
+        layer.updateExtents()
+
+        request = QgsFeatureRequest(QgsExpression(f'"edge_id" = {int(edge_id)}'))
+        request.setLimit(1)
+        feat = next(layer.getFeatures(request), None)
+        if feat is not None and feat.hasGeometry():
+            layer.selectByIds([feat.id()])
+            bbox = feat.geometry().boundingBox()
+            tools_qgis.zoom_to_rectangle(
+                bbox.xMinimum() - 15, bbox.yMinimum() - 15,
+                bbox.xMaximum() + 15, bbox.yMaximum() + 15)
+        else:
+            layer.triggerRepaint()
+
         msg = "Scada graph edge created"
         tools_qgis.show_info(msg, parameter=str(edge_id), dialog=dialog)
 

--- a/dbmodel/schemas/main/common/base/fct/gw_fct_scada_graph_build.sql
+++ b/dbmodel/schemas/main/common/base/fct/gw_fct_scada_graph_build.sql
@@ -22,11 +22,12 @@ SELECT SCHEMA_NAME.gw_fct_scada_graph_build($${"client":{"device":4, "lang":"es_
 Documentation:
 
 Orchestrates the scada graph Accept pipeline:
-1. INSERT om_scada_graph (object_1, object_2) -> gw_trg_scada_graph_builder trigger
-2. gw_fct_scada_graph_check (action fix)
-3. gw_fct_scada_graph_export
+1. Reject duplicate (object_1, object_2)
+2. INSERT om_scada_graph (object_1, object_2) -> gw_trg_scada_graph_builder fills THIS row only
+3. gw_fct_scada_graph_export (writes om_scada_graph_json; payload is NOT returned to the client)
 
-gw_fct_scada_graph_check and gw_fct_scada_graph_export remain available for standalone use.
+Skip gw_fct_scada_graph_check here: the trigger already writes geom/attrib/names for the new row.
+Check/fix remains available as a standalone maintenance call.
 */
 
 DECLARE
@@ -35,12 +36,8 @@ v_object_2 integer;
 v_edge_id integer;
 v_search_dist_routing integer;
 v_version text;
-v_check_data json;
 v_export_data json;
-v_check_result json;
 v_export_result json;
-v_export_data_body json;
-v_check_data_body json;
 v_error_context text;
 
 BEGIN
@@ -67,21 +64,17 @@ BEGIN
 			"version":"'||v_version||'","body":{"form":{},"data":{}}}')::json, 3547, null, null, null);
 	END IF;
 
+	IF EXISTS (
+		SELECT 1 FROM om_scada_graph
+		WHERE object_1 = v_object_1 AND object_2 = v_object_2
+	) THEN
+		RETURN gw_fct_json_create_return(('{"status":"Failed", "message":{"level":2, "text":"Scada graph edge already exists"},
+			"version":"'||v_version||'","body":{"form":{},"data":{}}}')::json, 3547, null, null, null);
+	END IF;
+
 	INSERT INTO om_scada_graph (object_1, object_2)
 	VALUES (v_object_1, v_object_2)
 	RETURNING edge_id INTO v_edge_id;
-
-	v_check_data := jsonb_set(
-		COALESCE(p_data::jsonb, '{}'::jsonb),
-		'{data,parameters}',
-		COALESCE(p_data -> 'data' -> 'parameters', '{}'::json)::jsonb
-			|| jsonb_build_object('object_1', v_object_1, 'object_2', v_object_2, 'action', 'fix')
-	)::json;
-
-	v_check_result := gw_fct_scada_graph_check(v_check_data);
-	IF v_check_result ->> 'status' IS DISTINCT FROM 'Accepted' THEN
-		RETURN v_check_result;
-	END IF;
 
 	v_export_data := jsonb_set(
 		COALESCE(p_data::jsonb, '{}'::jsonb),
@@ -99,9 +92,7 @@ BEGIN
 		RETURN v_export_result;
 	END IF;
 
-	v_check_data_body := COALESCE(v_check_result -> 'body' -> 'data', '{}'::json);
-	v_export_data_body := COALESCE(v_export_result -> 'body' -> 'data', '{}'::json);
-
+	-- Do not return export/check bodies: QGIS only needs edgeId. Full JSON stays in om_scada_graph_json.
 	RETURN gw_fct_json_create_return(json_build_object(
 		'status', 'Accepted',
 		'message', json_build_object('level', 1, 'text', 'Scada graph edge created successfully'),
@@ -111,9 +102,7 @@ BEGIN
 			'data', json_build_object(
 				'edgeId', v_edge_id,
 				'object_1', v_object_1,
-				'object_2', v_object_2,
-				'check', v_check_data_body,
-				'export', v_export_data_body
+				'object_2', v_object_2
 			)
 		)
 	)::json, 3547, null, null, null);

--- a/dbmodel/schemas/main/common/base/fct/gw_fct_scada_graph_check.sql
+++ b/dbmodel/schemas/main/common/base/fct/gw_fct_scada_graph_check.sql
@@ -40,6 +40,8 @@ v_expl_id text;
 v_action TEXT;
 v_object_1 integer;
 v_object_2 integer;
+v_edge_id integer;
+v_edge_filter text;
 
 -- Vars
 rec record;
@@ -67,6 +69,16 @@ BEGIN
 	v_action := COALESCE(p_data ->'data'->'parameters'->>'action', p_data ->'data'->>'action');
 	v_object_1 := COALESCE((p_data ->'data'->'parameters'->>'object_1')::integer, (p_data ->'data'->>'object_1')::integer);
 	v_object_2 := COALESCE((p_data ->'data'->'parameters'->>'object_2')::integer, (p_data ->'data'->>'object_2')::integer);
+	v_edge_id := COALESCE((p_data ->'data'->'parameters'->>'edgeId')::integer, (p_data ->'data'->>'edgeId')::integer);
+
+	IF v_edge_id IS NULL AND v_object_1 IS NOT NULL AND v_object_2 IS NOT NULL THEN
+		SELECT edge_id INTO v_edge_id
+		FROM om_scada_graph
+		WHERE object_1 = v_object_1 AND object_2 = v_object_2
+		ORDER BY edge_id DESC LIMIT 1;
+	END IF;
+
+	v_edge_filter := CASE WHEN v_edge_id IS NOT NULL THEN format(' AND a.edge_id = %s', v_edge_id) ELSE '' END;
 
 	IF v_expl_id IS NULL AND v_object_1 IS NOT NULL AND v_object_2 IS NOT NULL THEN
 		SELECT COALESCE(expl_1, expl_2)::text INTO v_expl_id
@@ -85,7 +97,8 @@ BEGIN
 	CREATE TEMP TABLE IF NOT EXISTS temp_anl_node (LIKE SCHEMA_NAME.anl_node INCLUDING ALL);
 	CREATE TEMP TABLE IF NOT EXISTS temp_audit_check_data (LIKE SCHEMA_NAME.audit_check_data INCLUDING ALL);
 
-	CREATE TEMP TABLE IF NOT EXISTS v_om_scada_graph AS
+	DROP TABLE IF EXISTS v_om_scada_graph;
+	CREATE TEMP TABLE v_om_scada_graph AS
 	WITH mec AS (
 			SELECT a_1.edge_id,
 				a_1.order_id,
@@ -104,6 +117,7 @@ BEGIN
 			FROM om_scada_graph a_1
 				LEFT JOIN node b_1 ON a_1.object_1 = b_1.node_id::integer
 				LEFT JOIN node c_1 ON a_1.object_2 = c_1.node_id::integer
+			WHERE v_edge_id IS NULL OR a_1.edge_id = v_edge_id
 			)
 	SELECT a.edge_id,
 		a.order_id,
@@ -127,15 +141,17 @@ BEGIN
 		LEFT JOIN dma e ON a.dma_id_1 = e.dma_id
 		LEFT JOIN dma f ON a.dma_id_2 = f.dma_id;
 
+	DROP TABLE IF EXISTS temp_om_scada_graph;
 	EXECUTE '
-	CREATE TEMP TABLE IF NOT EXISTS temp_om_scada_graph AS 
+	CREATE TEMP TABLE temp_om_scada_graph AS 
 	SELECT a.edge_id, a.the_geom, b.the_geom AS geom_1, c.the_geom AS geom_2,
 	a.object_1, a.objecttype_1, b.state AS state_1, a.expl_1, 
 	a.object_2, a.objecttype_2, c.state AS state_2, a.expl_2
 	FROM om_scada_graph a
 	LEFT JOIN node b ON a.object_1 = b.node_id::int
 	LEFT JOIN node c ON a.object_2 = c.node_id::int
-	WHERE b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||')';
+	WHERE (b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||'))'
+	|| v_edge_filter;
 
 
 	INSERT INTO temp_audit_check_data (fid, result_id, criticity, error_message) VALUES (1, null, 4, concat('CHECK DATA QUALITY - OM_SCADA_GRAPH'));
@@ -179,7 +195,8 @@ BEGIN
 	FROM om_scada_graph a
 	LEFT JOIN node b ON a.object_1 = b.node_id::int
 	LEFT JOIN node c ON a.object_2 = c.node_id::int
-	WHERE b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||')
+	WHERE (b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||'))'
+	|| v_edge_filter || '
 	), mec AS (
 		SELECT * FROM temp_om_scada_graph a WHERE object_1 IN (SELECT node_1 FROM arc UNION ALL SELECT node_2 FROM arc)
 	)
@@ -205,7 +222,8 @@ BEGIN
 	FROM om_scada_graph a
 	LEFT JOIN node b ON a.object_1 = b.node_id::int
 	LEFT JOIN node c ON a.object_2 = c.node_id::int
-	WHERE b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||')
+	WHERE (b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||'))'
+	|| v_edge_filter || '
 	), mec AS (
 		SELECT * FROM temp_om_scada_graph a WHERE object_2 IN (SELECT node_1 FROM arc UNION ALL SELECT node_2 FROM arc)
 	)
@@ -242,13 +260,12 @@ BEGIN
 	ELSIF v_action = 'fix' THEN -- update attrib.om_scada_graph AND ALL obsolete attrs
 	
 		FOR rec IN EXECUTE '
-		SELECT edge_id, object_1, object_2, expl_1, expl_2 FROM om_scada_graph
-		WHERE (expl_1 IN ('||v_expl_id||') OR expl_2 IN ('||v_expl_id||'))
+		SELECT edge_id, object_1, object_2, expl_1, expl_2 FROM om_scada_graph a
+		WHERE (expl_1 IN ('||v_expl_id||') OR expl_2 IN ('||v_expl_id||'))'
+		|| v_edge_filter || '
 		ORDER BY edge_id asc'
 		LOOP
-	
-			RAISE NOTICE '%', rec.edge_id;
-			
+
 			EXECUTE format(
 			'SELECT json_build_object(
 				''arcs'', json_agg(edge)
@@ -295,10 +312,11 @@ BEGIN
 			FROM mic
 
 		LOOP
-			
-			RAISE NOTICE '%', rec;
-		
+
 			v_sql = 'UPDATE om_scada_graph t SET '||rec.om_column||' = a.'||rec.column_name||' FROM '||rec.man_addf_table||' a WHERE a.node_id::int = t.object_'||rec.serie||' and a.'||rec.column_name||' is not null';
+			IF v_edge_id IS NOT NULL THEN
+				v_sql := v_sql || format(' AND t.edge_id = %s', v_edge_id);
+			END IF;
 			EXECUTE v_sql;	
 	
 		END LOOP;
@@ -315,6 +333,7 @@ BEGIN
 								        ('object_2', g.object_2, 'objecttype_2', g.objecttype_2, 'object_name_2', g.object_name_2)
 								) AS v(object_id_col, object_id_val, object_type_col, object_type_val, object_name_col, object_name)
 				LEFT JOIN cat_feature b ON v.object_type_val = b.id
+				WHERE v_edge_id IS NULL OR g.edge_id = v_edge_id
 			)
 			SELECT DISTINCT sys_man_table, concat('object_name_', serie) AS object_name_col, serie FROM mec 
 			CROSS JOIN generate_series(1, 2) AS serie
@@ -325,6 +344,9 @@ BEGIN
 		LOOP
 			
 			v_sql = 'UPDATE om_scada_graph t SET '||rec.object_name_col||' = a.name from '||rec.sys_man_table||' a where a.node_id::int = t.object_'||rec.serie||' and a.name is not null';
+			IF v_edge_id IS NOT NULL THEN
+				v_sql := v_sql || format(' AND t.edge_id = %s', v_edge_id);
+			END IF;
 		
 			EXECUTE v_sql;
 			

--- a/dbmodel/schemas/main/common/base/fct/gw_fct_scada_graph_export.sql
+++ b/dbmodel/schemas/main/common/base/fct/gw_fct_scada_graph_export.sql
@@ -125,7 +125,7 @@ BEGIN
 
 	RETURN gw_fct_json_create_return(('{"status":"Accepted", "message":{"level":1, "text":"Network JSON graph successfully created"}, "version":""'||
 				',"body":{"form":{}'||
-				',"data":{  "info":'||v_result_info||', "result":'||v_json_result_return||'}}'||
+				',"data":{  "info":'||v_result_info||'}}'||
 			'}')::json, 3546, null, null, null);
 
 EXCEPTION WHEN OTHERS THEN

--- a/dbmodel/schemas/main/common/base/ftrg/gw_trg_scada_graph_builder.sql
+++ b/dbmodel/schemas/main/common/base/ftrg/gw_trg_scada_graph_builder.sql
@@ -13,10 +13,10 @@ AS $function$
 /*
 
 Documentation:
-Takes the node_1 and node_2 (from p_data) and connects them using pgrouting. Then, their attributes are inserted into  om_scada_graph table.
+Takes object_1 and object_2 and connects them with pgr_dijkstra (operative arcs).
+Writes the_geom, attrib.arcs and is_scadamap on the path.
 
-TROUBLESHOOTING: If CREATE TEMP TABLE temp_graph fails trying to invoke json_array_elements en un no-array, 
-it's because there is no continuity in the path, therefore, the profile does not return de keys needed to create the table. 
+TROUBLESHOOTING: If it raises "No network path", there is no continuity between the two nodes. 
 
  */
 
@@ -31,7 +31,6 @@ v_sql_1 TEXT;
 
 -- Vars
 v_arc_geom public.geometry(LINESTRING, SRID_VALUE);
-v_test int;
 v_sql TEXT;
 v_arcs TEXT;
 v_column_name TEXT;
@@ -58,40 +57,55 @@ BEGIN
 	IF TG_WHEN = 'BEFORE' THEN
 	
 	    IF TG_OP IN ('INSERT', 'UPDATE') THEN
-	
-	    	-- prepare data (=get arcs i nodes of the routing)   		
-    		EXECUTE format(
-    		'CREATE TEMP TABLE temp_graph as
-		    WITH mec AS (
-		        SELECT gw_fct_getprofilevalues(''{"data":{"initNode":"%s", "endNode":"%s", "linksDistance":5}}'') AS v_return
-		    )
-		    SELECT 
-		        (json_array_elements(v_return -> ''body'' -> ''data'' -> ''node'') ->> ''node_id'')::int as node_id,
-		        (json_array_elements(v_return -> ''body'' -> ''data'' -> ''arc'') ->> ''arc_id'')::int as arc_id
-		    FROM mec', 
-		    NEW.object_1, 
-		    NEW.object_2
-			);
-			
-			-- get values to update row
-			EXECUTE '
-			SELECT st_astext(ST_LineMerge(ST_Collect(b.the_geom))) FROM temp_graph a
-	        JOIN arc b ON a.arc_id = b.arc_id::int'
-			INTO NEW.the_geom;
-		
-			EXECUTE '
-			select 
-			json_build_object(
-				''arcs'', json_agg(arc_id)
-			) from temp_graph where arc_id is not null' 
-			INTO NEW.attrib;
-			
-		
-	      	EXECUTE 'UPDATE arc SET is_scadamap = TRUE WHERE arc_id::int IN (SELECT arc_id FROM temp_graph)';
-			EXECUTE 'UPDATE node SET is_scadamap = TRUE WHERE node_id::int IN (SELECT node_id FROM temp_graph)';
-	
+
+			IF EXISTS (
+				SELECT 1 FROM om_scada_graph g
+				WHERE g.object_1 = NEW.object_1
+				  AND g.object_2 = NEW.object_2
+				  AND (TG_OP = 'INSERT' OR g.edge_id IS DISTINCT FROM NEW.edge_id)
+			) THEN
+				RAISE EXCEPTION 'Scada graph edge already exists for object_1=% and object_2=%', NEW.object_1, NEW.object_2
+					USING ERRCODE = 'unique_violation';
+			END IF;
+
+	    	-- shortest path on operative arcs (not gw_fct_getprofilevalues)
 			DROP TABLE IF EXISTS temp_graph;
-	      
+			CREATE TEMP TABLE temp_graph AS
+			SELECT d.edge AS arc_id, d.node AS node_id
+			FROM pgr_dijkstra(
+				$pgr$SELECT arc_id::int AS id, node_1::int AS source, node_2::int AS target, 1.0 AS cost
+				FROM arc WHERE state = 1 AND node_1 IS NOT NULL AND node_2 IS NOT NULL$pgr$,
+				NEW.object_1,
+				NEW.object_2,
+				directed := false
+			) d
+			WHERE d.edge > 0;
+
+			IF NOT EXISTS (SELECT 1 FROM temp_graph) THEN
+				RAISE EXCEPTION 'No network path between object_1=% and object_2=%', NEW.object_1, NEW.object_2;
+			END IF;
+
+			SELECT ST_Multi(ST_LineMerge(ST_Collect(b.the_geom)))
+			FROM temp_graph a
+			JOIN arc b ON a.arc_id = b.arc_id::int
+			INTO NEW.the_geom;
+
+			SELECT json_build_object('arcs', json_agg(arc_id))
+			FROM temp_graph
+			WHERE arc_id IS NOT NULL
+			INTO NEW.attrib;
+
+			UPDATE arc SET is_scadamap = TRUE
+			WHERE arc_id::int IN (SELECT arc_id FROM temp_graph);
+			UPDATE node SET is_scadamap = TRUE
+			WHERE node_id::int IN (
+				SELECT node_id FROM temp_graph
+				UNION SELECT NEW.object_1
+				UNION SELECT NEW.object_2
+			);
+
+			DROP TABLE IF EXISTS temp_graph;
+
 			RETURN NEW;
 		END IF;
 	
@@ -99,7 +113,8 @@ BEGIN
 	
 		IF TG_OP IN ('INSERT', 'UPDATE') THEN
 
-		CREATE TEMP TABLE IF NOT EXISTS v_om_scada_graph  AS
+		DROP TABLE IF EXISTS v_om_scada_graph;
+		CREATE TEMP TABLE v_om_scada_graph AS
 		WITH mec AS (
 			SELECT a_1.edge_id,
 				a_1.order_id,
@@ -118,6 +133,7 @@ BEGIN
 			FROM  om_scada_graph a_1
 				LEFT JOIN node b_1 ON a_1.object_1 = b_1.node_id::integer
 				LEFT JOIN node c_1 ON a_1.object_2 = c_1.node_id::integer
+			WHERE a_1.edge_id = NEW.edge_id
 		)
 		SELECT a.edge_id,
 			a.order_id,
@@ -159,14 +175,15 @@ BEGIN
 				WHERE edge_id = NEW.edge_id
 			)a WHERE t.edge_id = a.edge_id;
 			
-			-- attrs from the graph 
-	 		UPDATE om_scada_graph t SET order_id = a.agg_cost FROM (
-				SELECT a.agg_cost, b.edge_id FROM pgr_drivingdistance(
-				'SELECT edge_id AS id, object_1 AS SOURCE, object_2 AS TARGET, 1.0 AS COST FROM om_scada_graph',
-				(SELECT array_agg(object_1) FROM  om_scada_graph WHERE object_1 NOT IN (SELECT object_2 FROM om_scada_graph)),
-				9999,
-				FALSE)a JOIN om_scada_graph b ON a.edge = b.edge_id
-			)a WHERE t.edge_id = a.edge_id;
+			-- order_id only for this row (parent hop + 1, or 1 if object_1 is a root)
+	 		UPDATE om_scada_graph t SET order_id = COALESCE((
+				SELECT MIN(g.order_id) + 1
+				FROM om_scada_graph g
+				WHERE g.object_2 = NEW.object_1
+				  AND g.edge_id IS DISTINCT FROM NEW.edge_id
+				  AND g.order_id IS NOT NULL
+			), 1)
+			WHERE t.edge_id = NEW.edge_id;
 		
 			v_sql = '
 			SELECT v.object_id_col, v.object_id_val, v.object_type_col, v.object_type_val, v.object_name_col,

--- a/dbmodel/schemas/main/common/functions/fct/gw_fct_scada_graph_build.sql
+++ b/dbmodel/schemas/main/common/functions/fct/gw_fct_scada_graph_build.sql
@@ -22,11 +22,12 @@ SELECT SCHEMA_NAME.gw_fct_scada_graph_build($${"client":{"device":4, "lang":"es_
 Documentation:
 
 Orchestrates the scada graph Accept pipeline:
-1. INSERT om_scada_graph (object_1, object_2) -> gw_trg_scada_graph_builder trigger
-2. gw_fct_scada_graph_check (action fix)
-3. gw_fct_scada_graph_export
+1. Reject duplicate (object_1, object_2)
+2. INSERT om_scada_graph (object_1, object_2) -> gw_trg_scada_graph_builder fills THIS row only
+3. gw_fct_scada_graph_export (writes om_scada_graph_json; payload is NOT returned to the client)
 
-gw_fct_scada_graph_check and gw_fct_scada_graph_export remain available for standalone use.
+Skip gw_fct_scada_graph_check here: the trigger already writes geom/attrib/names for the new row.
+Check/fix remains available as a standalone maintenance call.
 */
 
 DECLARE
@@ -35,12 +36,8 @@ v_object_2 integer;
 v_edge_id integer;
 v_search_dist_routing integer;
 v_version text;
-v_check_data json;
 v_export_data json;
-v_check_result json;
 v_export_result json;
-v_export_data_body json;
-v_check_data_body json;
 v_error_context text;
 
 BEGIN
@@ -67,21 +64,17 @@ BEGIN
 			"version":"'||v_version||'","body":{"form":{},"data":{}}}')::json, 3547, null, null, null);
 	END IF;
 
+	IF EXISTS (
+		SELECT 1 FROM om_scada_graph
+		WHERE object_1 = v_object_1 AND object_2 = v_object_2
+	) THEN
+		RETURN gw_fct_json_create_return(('{"status":"Failed", "message":{"level":2, "text":"Scada graph edge already exists"},
+			"version":"'||v_version||'","body":{"form":{},"data":{}}}')::json, 3547, null, null, null);
+	END IF;
+
 	INSERT INTO om_scada_graph (object_1, object_2)
 	VALUES (v_object_1, v_object_2)
 	RETURNING edge_id INTO v_edge_id;
-
-	v_check_data := jsonb_set(
-		COALESCE(p_data::jsonb, '{}'::jsonb),
-		'{data,parameters}',
-		COALESCE(p_data -> 'data' -> 'parameters', '{}'::json)::jsonb
-			|| jsonb_build_object('object_1', v_object_1, 'object_2', v_object_2, 'action', 'fix')
-	)::json;
-
-	v_check_result := gw_fct_scada_graph_check(v_check_data);
-	IF v_check_result ->> 'status' IS DISTINCT FROM 'Accepted' THEN
-		RETURN v_check_result;
-	END IF;
 
 	v_export_data := jsonb_set(
 		COALESCE(p_data::jsonb, '{}'::jsonb),
@@ -99,9 +92,7 @@ BEGIN
 		RETURN v_export_result;
 	END IF;
 
-	v_check_data_body := COALESCE(v_check_result -> 'body' -> 'data', '{}'::json);
-	v_export_data_body := COALESCE(v_export_result -> 'body' -> 'data', '{}'::json);
-
+	-- Do not return export/check bodies: QGIS only needs edgeId. Full JSON stays in om_scada_graph_json.
 	RETURN gw_fct_json_create_return(json_build_object(
 		'status', 'Accepted',
 		'message', json_build_object('level', 1, 'text', 'Scada graph edge created successfully'),
@@ -111,9 +102,7 @@ BEGIN
 			'data', json_build_object(
 				'edgeId', v_edge_id,
 				'object_1', v_object_1,
-				'object_2', v_object_2,
-				'check', v_check_data_body,
-				'export', v_export_data_body
+				'object_2', v_object_2
 			)
 		)
 	)::json, 3547, null, null, null);

--- a/dbmodel/schemas/main/common/functions/fct/gw_fct_scada_graph_check.sql
+++ b/dbmodel/schemas/main/common/functions/fct/gw_fct_scada_graph_check.sql
@@ -40,6 +40,8 @@ v_expl_id text;
 v_action TEXT;
 v_object_1 integer;
 v_object_2 integer;
+v_edge_id integer;
+v_edge_filter text;
 
 -- Vars
 rec record;
@@ -67,6 +69,16 @@ BEGIN
 	v_action := COALESCE(p_data ->'data'->'parameters'->>'action', p_data ->'data'->>'action');
 	v_object_1 := COALESCE((p_data ->'data'->'parameters'->>'object_1')::integer, (p_data ->'data'->>'object_1')::integer);
 	v_object_2 := COALESCE((p_data ->'data'->'parameters'->>'object_2')::integer, (p_data ->'data'->>'object_2')::integer);
+	v_edge_id := COALESCE((p_data ->'data'->'parameters'->>'edgeId')::integer, (p_data ->'data'->>'edgeId')::integer);
+
+	IF v_edge_id IS NULL AND v_object_1 IS NOT NULL AND v_object_2 IS NOT NULL THEN
+		SELECT edge_id INTO v_edge_id
+		FROM om_scada_graph
+		WHERE object_1 = v_object_1 AND object_2 = v_object_2
+		ORDER BY edge_id DESC LIMIT 1;
+	END IF;
+
+	v_edge_filter := CASE WHEN v_edge_id IS NOT NULL THEN format(' AND a.edge_id = %s', v_edge_id) ELSE '' END;
 
 	IF v_expl_id IS NULL AND v_object_1 IS NOT NULL AND v_object_2 IS NOT NULL THEN
 		SELECT COALESCE(expl_1, expl_2)::text INTO v_expl_id
@@ -85,7 +97,8 @@ BEGIN
 	CREATE TEMP TABLE IF NOT EXISTS temp_anl_node (LIKE SCHEMA_NAME.anl_node INCLUDING ALL);
 	CREATE TEMP TABLE IF NOT EXISTS temp_audit_check_data (LIKE SCHEMA_NAME.audit_check_data INCLUDING ALL);
 
-	CREATE TEMP TABLE IF NOT EXISTS v_om_scada_graph AS
+	DROP TABLE IF EXISTS v_om_scada_graph;
+	CREATE TEMP TABLE v_om_scada_graph AS
 	WITH mec AS (
 			SELECT a_1.edge_id,
 				a_1.order_id,
@@ -104,6 +117,7 @@ BEGIN
 			FROM om_scada_graph a_1
 				LEFT JOIN node b_1 ON a_1.object_1 = b_1.node_id::integer
 				LEFT JOIN node c_1 ON a_1.object_2 = c_1.node_id::integer
+			WHERE v_edge_id IS NULL OR a_1.edge_id = v_edge_id
 			)
 	SELECT a.edge_id,
 		a.order_id,
@@ -127,15 +141,21 @@ BEGIN
 		LEFT JOIN dma e ON a.dma_id_1 = e.dma_id
 		LEFT JOIN dma f ON a.dma_id_2 = f.dma_id;
 
+	-- Quality scans are for action=check only. action=fix must not pay for
+	-- full-network orphan queries (node_1/node_2 UNION ALL FROM arc).
+	IF v_action IS DISTINCT FROM 'fix' THEN
+
+	DROP TABLE IF EXISTS temp_om_scada_graph;
 	EXECUTE '
-	CREATE TEMP TABLE IF NOT EXISTS temp_om_scada_graph AS 
+	CREATE TEMP TABLE temp_om_scada_graph AS 
 	SELECT a.edge_id, a.the_geom, b.the_geom AS geom_1, c.the_geom AS geom_2,
 	a.object_1, a.objecttype_1, b.state AS state_1, a.expl_1, 
 	a.object_2, a.objecttype_2, c.state AS state_2, a.expl_2
 	FROM om_scada_graph a
 	LEFT JOIN node b ON a.object_1 = b.node_id::int
 	LEFT JOIN node c ON a.object_2 = c.node_id::int
-	WHERE b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||')';
+	WHERE (b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||'))'
+	|| v_edge_filter;
 
 
 	INSERT INTO temp_audit_check_data (fid, result_id, criticity, error_message) VALUES (1, null, 4, concat('CHECK DATA QUALITY - OM_SCADA_GRAPH'));
@@ -162,15 +182,6 @@ BEGIN
 	
 
 	raise notice '2 - object_1 and object_2 must not be orphan nodes';
-/*
-	INSERT INTO temp_anl_node (fid, result_id, node_id, nodecat_id, state, expl_id, arc_id, the_geom, descript)
-	SELECT v_fid, '2', object_1, objecttype_1, state_1, expl_1, edge_id, geom_1, 
-	concat('Object_1 from edge_id ', edge_id, ' is orphan.') 
-	FROM temp_om_scada_graph a 
-	WHERE object_1::text NOT IN (
-		SELECT node_1 FROM arc UNION ALL SELECT node_2 FROM arc
-	);
-*/
 	execute 'INSERT INTO temp_anl_node (fid, result_id, node_id, nodecat_id, state, expl_id, arc_id, the_geom,descript)
 	WITH temp_om_scada_graph AS (
 	SELECT a.edge_id, a.the_geom, b.the_geom AS geom_1, c.the_geom AS geom_2,
@@ -179,7 +190,8 @@ BEGIN
 	FROM om_scada_graph a
 	LEFT JOIN node b ON a.object_1 = b.node_id::int
 	LEFT JOIN node c ON a.object_2 = c.node_id::int
-	WHERE b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||')
+	WHERE (b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||'))'
+	|| v_edge_filter || '
 	), mec AS (
 		SELECT * FROM temp_om_scada_graph a WHERE object_1 IN (SELECT node_1 FROM arc UNION ALL SELECT node_2 FROM arc)
 	)
@@ -187,16 +199,6 @@ BEGIN
 	concat(''Object_1 from edge_id '', edge_id, '' is orphan.'') FROM temp_om_scada_graph 
 	WHERE object_1 NOT IN (SELECT object_1 FROM mec)';
 
-
-/*
-	INSERT INTO temp_anl_node (fid, result_id, node_id, nodecat_id, state, expl_id, arc_id, the_geom,descript)
-	SELECT v_fid, '2', object_2, objecttype_2, state_2, expl_2, edge_id, geom_2, 
-	concat('Object_2 from edge_id ', edge_id, ' is orphan.') 
-	FROM temp_om_scada_graph a
-	WHERE a.object_2::text NOT IN (
-		SELECT node_1 FROM arc UNION ALL SELECT node_2 FROM arc
-	);
-*/
 	execute 'INSERT INTO temp_anl_node (fid, result_id, node_id, nodecat_id, state, expl_id, arc_id, the_geom,descript)
 	WITH temp_om_scada_graph AS (
 	SELECT a.edge_id, a.the_geom, b.the_geom AS geom_1, c.the_geom AS geom_2,
@@ -205,7 +207,8 @@ BEGIN
 	FROM om_scada_graph a
 	LEFT JOIN node b ON a.object_1 = b.node_id::int
 	LEFT JOIN node c ON a.object_2 = c.node_id::int
-	WHERE b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||')
+	WHERE (b.expl_id IN ('||v_expl_id||') OR c.expl_id IN ('||v_expl_id||'))'
+	|| v_edge_filter || '
 	), mec AS (
 		SELECT * FROM temp_om_scada_graph a WHERE object_2 IN (SELECT node_1 FROM arc UNION ALL SELECT node_2 FROM arc)
 	)
@@ -221,6 +224,8 @@ BEGIN
 	SELECT concat('The edge_id ', edge_id, ' has at least 1 object_id missing in table of nodes') FROM temp_om_scada_graph 
 	WHERE object_1 NOT IN (SELECT node_id FROM node)
 	OR object_2 NOT IN (SELECT node_id FROM node);
+
+	END IF;
 
 	
 
@@ -242,13 +247,12 @@ BEGIN
 	ELSIF v_action = 'fix' THEN -- update attrib.om_scada_graph AND ALL obsolete attrs
 	
 		FOR rec IN EXECUTE '
-		SELECT edge_id, object_1, object_2, expl_1, expl_2 FROM om_scada_graph
-		WHERE (expl_1 IN ('||v_expl_id||') OR expl_2 IN ('||v_expl_id||'))
+		SELECT edge_id, object_1, object_2, expl_1, expl_2 FROM om_scada_graph a
+		WHERE (expl_1 IN ('||v_expl_id||') OR expl_2 IN ('||v_expl_id||'))'
+		|| v_edge_filter || '
 		ORDER BY edge_id asc'
 		LOOP
-	
-			RAISE NOTICE '%', rec.edge_id;
-			
+
 			EXECUTE format(
 			'SELECT json_build_object(
 				''arcs'', json_agg(edge)
@@ -295,10 +299,11 @@ BEGIN
 			FROM mic
 
 		LOOP
-			
-			RAISE NOTICE '%', rec;
-		
+
 			v_sql = 'UPDATE om_scada_graph t SET '||rec.om_column||' = a.'||rec.column_name||' FROM '||rec.man_addf_table||' a WHERE a.node_id::int = t.object_'||rec.serie||' and a.'||rec.column_name||' is not null';
+			IF v_edge_id IS NOT NULL THEN
+				v_sql := v_sql || format(' AND t.edge_id = %s', v_edge_id);
+			END IF;
 			EXECUTE v_sql;	
 	
 		END LOOP;
@@ -315,6 +320,7 @@ BEGIN
 								        ('object_2', g.object_2, 'objecttype_2', g.objecttype_2, 'object_name_2', g.object_name_2)
 								) AS v(object_id_col, object_id_val, object_type_col, object_type_val, object_name_col, object_name)
 				LEFT JOIN cat_feature b ON v.object_type_val = b.id
+				WHERE v_edge_id IS NULL OR g.edge_id = v_edge_id
 			)
 			SELECT DISTINCT sys_man_table, concat('object_name_', serie) AS object_name_col, serie FROM mec 
 			CROSS JOIN generate_series(1, 2) AS serie
@@ -325,6 +331,9 @@ BEGIN
 		LOOP
 			
 			v_sql = 'UPDATE om_scada_graph t SET '||rec.object_name_col||' = a.name from '||rec.sys_man_table||' a where a.node_id::int = t.object_'||rec.serie||' and a.name is not null';
+			IF v_edge_id IS NOT NULL THEN
+				v_sql := v_sql || format(' AND t.edge_id = %s', v_edge_id);
+			END IF;
 		
 			EXECUTE v_sql;
 			

--- a/dbmodel/schemas/main/common/functions/fct/gw_fct_scada_graph_export.sql
+++ b/dbmodel/schemas/main/common/functions/fct/gw_fct_scada_graph_export.sql
@@ -125,7 +125,7 @@ BEGIN
 
 	RETURN gw_fct_json_create_return(('{"status":"Accepted", "message":{"level":1, "text":"Network JSON graph successfully created"}, "version":""'||
 				',"body":{"form":{}'||
-				',"data":{  "info":'||v_result_info||', "result":'||v_json_result_return||'}}'||
+				',"data":{  "info":'||v_result_info||'}}'||
 			'}')::json, 3546, null, null, null);
 
 EXCEPTION WHEN OTHERS THEN

--- a/dbmodel/schemas/main/common/functions/ftrg/gw_trg_scada_graph_builder.sql
+++ b/dbmodel/schemas/main/common/functions/ftrg/gw_trg_scada_graph_builder.sql
@@ -13,10 +13,10 @@ AS $function$
 /*
 
 Documentation:
-Takes the node_1 and node_2 (from p_data) and connects them using pgrouting. Then, their attributes are inserted into  om_scada_graph table.
+Takes object_1 and object_2 and connects them with pgr_dijkstra (operative arcs).
+Writes the_geom, attrib.arcs and is_scadamap on the path.
 
-TROUBLESHOOTING: If CREATE TEMP TABLE temp_graph fails trying to invoke json_array_elements en un no-array, 
-it's because there is no continuity in the path, therefore, the profile does not return de keys needed to create the table. 
+TROUBLESHOOTING: If it raises "No network path", there is no continuity between the two nodes. 
 
  */
 
@@ -31,7 +31,6 @@ v_sql_1 TEXT;
 
 -- Vars
 v_arc_geom public.geometry(LINESTRING, SRID_VALUE);
-v_test int;
 v_sql TEXT;
 v_arcs TEXT;
 v_column_name TEXT;
@@ -58,40 +57,55 @@ BEGIN
 	IF TG_WHEN = 'BEFORE' THEN
 	
 	    IF TG_OP IN ('INSERT', 'UPDATE') THEN
-	
-	    	-- prepare data (=get arcs i nodes of the routing)   		
-    		EXECUTE format(
-    		'CREATE TEMP TABLE temp_graph as
-		    WITH mec AS (
-		        SELECT gw_fct_getprofilevalues(''{"data":{"initNode":"%s", "endNode":"%s", "linksDistance":5}}'') AS v_return
-		    )
-		    SELECT 
-		        (json_array_elements(v_return -> ''body'' -> ''data'' -> ''node'') ->> ''node_id'')::int as node_id,
-		        (json_array_elements(v_return -> ''body'' -> ''data'' -> ''arc'') ->> ''arc_id'')::int as arc_id
-		    FROM mec', 
-		    NEW.object_1, 
-		    NEW.object_2
-			);
-			
-			-- get values to update row
-			EXECUTE '
-			SELECT st_astext(ST_LineMerge(ST_Collect(b.the_geom))) FROM temp_graph a
-	        JOIN arc b ON a.arc_id = b.arc_id::int'
-			INTO NEW.the_geom;
-		
-			EXECUTE '
-			select 
-			json_build_object(
-				''arcs'', json_agg(arc_id)
-			) from temp_graph where arc_id is not null' 
-			INTO NEW.attrib;
-			
-		
-	      	EXECUTE 'UPDATE arc SET is_scadamap = TRUE WHERE arc_id::int IN (SELECT arc_id FROM temp_graph)';
-			EXECUTE 'UPDATE node SET is_scadamap = TRUE WHERE node_id::int IN (SELECT node_id FROM temp_graph)';
-	
+
+			IF EXISTS (
+				SELECT 1 FROM om_scada_graph g
+				WHERE g.object_1 = NEW.object_1
+				  AND g.object_2 = NEW.object_2
+				  AND (TG_OP = 'INSERT' OR g.edge_id IS DISTINCT FROM NEW.edge_id)
+			) THEN
+				RAISE EXCEPTION 'Scada graph edge already exists for object_1=% and object_2=%', NEW.object_1, NEW.object_2
+					USING ERRCODE = 'unique_violation';
+			END IF;
+
+	    	-- shortest path on operative arcs (not gw_fct_getprofilevalues)
 			DROP TABLE IF EXISTS temp_graph;
-	      
+			CREATE TEMP TABLE temp_graph AS
+			SELECT d.edge AS arc_id, d.node AS node_id
+			FROM pgr_dijkstra(
+				$pgr$SELECT arc_id::int AS id, node_1::int AS source, node_2::int AS target, 1.0 AS cost
+				FROM arc WHERE state = 1 AND node_1 IS NOT NULL AND node_2 IS NOT NULL$pgr$,
+				NEW.object_1,
+				NEW.object_2,
+				directed := false
+			) d
+			WHERE d.edge > 0;
+
+			IF NOT EXISTS (SELECT 1 FROM temp_graph) THEN
+				RAISE EXCEPTION 'No network path between object_1=% and object_2=%', NEW.object_1, NEW.object_2;
+			END IF;
+
+			SELECT ST_Multi(ST_LineMerge(ST_Collect(b.the_geom)))
+			FROM temp_graph a
+			JOIN arc b ON a.arc_id = b.arc_id::int
+			INTO NEW.the_geom;
+
+			SELECT json_build_object('arcs', json_agg(arc_id))
+			FROM temp_graph
+			WHERE arc_id IS NOT NULL
+			INTO NEW.attrib;
+
+			UPDATE arc SET is_scadamap = TRUE
+			WHERE arc_id::int IN (SELECT arc_id FROM temp_graph);
+			UPDATE node SET is_scadamap = TRUE
+			WHERE node_id::int IN (
+				SELECT node_id FROM temp_graph
+				UNION SELECT NEW.object_1
+				UNION SELECT NEW.object_2
+			);
+
+			DROP TABLE IF EXISTS temp_graph;
+
 			RETURN NEW;
 		END IF;
 	
@@ -99,7 +113,8 @@ BEGIN
 	
 		IF TG_OP IN ('INSERT', 'UPDATE') THEN
 
-		CREATE TEMP TABLE IF NOT EXISTS v_om_scada_graph  AS
+		DROP TABLE IF EXISTS v_om_scada_graph;
+		CREATE TEMP TABLE v_om_scada_graph AS
 		WITH mec AS (
 			SELECT a_1.edge_id,
 				a_1.order_id,
@@ -118,6 +133,7 @@ BEGIN
 			FROM  om_scada_graph a_1
 				LEFT JOIN node b_1 ON a_1.object_1 = b_1.node_id::integer
 				LEFT JOIN node c_1 ON a_1.object_2 = c_1.node_id::integer
+			WHERE a_1.edge_id = NEW.edge_id
 		)
 		SELECT a.edge_id,
 			a.order_id,
@@ -159,14 +175,15 @@ BEGIN
 				WHERE edge_id = NEW.edge_id
 			)a WHERE t.edge_id = a.edge_id;
 			
-			-- attrs from the graph 
-	 		UPDATE om_scada_graph t SET order_id = a.agg_cost FROM (
-				SELECT a.agg_cost, b.edge_id FROM pgr_drivingdistance(
-				'SELECT edge_id AS id, object_1 AS SOURCE, object_2 AS TARGET, 1.0 AS COST FROM om_scada_graph',
-				(SELECT array_agg(object_1) FROM  om_scada_graph WHERE object_1 NOT IN (SELECT object_2 FROM om_scada_graph)),
-				9999,
-				FALSE)a JOIN om_scada_graph b ON a.edge = b.edge_id
-			)a WHERE t.edge_id = a.edge_id;
+			-- order_id only for this row (parent hop + 1, or 1 if object_1 is a root)
+	 		UPDATE om_scada_graph t SET order_id = COALESCE((
+				SELECT MIN(g.order_id) + 1
+				FROM om_scada_graph g
+				WHERE g.object_2 = NEW.object_1
+				  AND g.edge_id IS DISTINCT FROM NEW.edge_id
+				  AND g.order_id IS NOT NULL
+			), 1)
+			WHERE t.edge_id = NEW.edge_id;
 		
 			v_sql = '
 			SELECT v.object_id_col, v.object_id_val, v.object_type_col, v.object_type_val, v.object_name_col,

--- a/dbmodel/schemas/main/common/updates/4/17/0/patch.sql
+++ b/dbmodel/schemas/main/common/updates/4/17/0/patch.sql
@@ -1281,3 +1281,13 @@ WHERE columnname = 'muni_id'
   AND formtype = 'form_feature'
   AND tabname = 'tab_data'
   AND widgettype = 'combo';
+
+-- om_scada_graph: unique (object_1, object_2) and drop leftover duplicate edges
+DELETE FROM om_scada_graph a
+USING om_scada_graph b
+WHERE a.edge_id > b.edge_id
+  AND a.object_1 = b.object_1
+  AND a.object_2 = b.object_2;
+
+CREATE UNIQUE INDEX IF NOT EXISTS om_scada_graph_object_1_object_2_uidx
+ON om_scada_graph (object_1, object_2);

--- a/dbmodel/test/ws/function/test_gw_fct_scada_graph_build.sql
+++ b/dbmodel/test/ws/function/test_gw_fct_scada_graph_build.sql
@@ -1,0 +1,73 @@
+/*
+This file is part of Giswater
+The program is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version.
+*/
+BEGIN;
+
+-- Suppress NOTICE messages
+SET client_min_messages TO WARNING;
+
+SET search_path = "SCHEMA_NAME", public, pg_catalog;
+
+SELECT plan(5);
+
+CREATE USER plan_user;
+GRANT role_plan to plan_user;
+
+CREATE USER epa_user;
+GRANT role_epa to epa_user;
+
+CREATE USER edit_user;
+GRANT role_edit to edit_user;
+
+CREATE USER om_user;
+GRANT role_om to om_user;
+
+CREATE USER basic_user;
+GRANT role_basic to basic_user;
+
+SELECT is(
+    (gw_fct_scada_graph_build($${"client":{"device":4, "lang":"es_ES", "infoType":1, "epsg":25831},
+    "form":{}, "feature":{}, "data":{"parameters":{"object_1":1109}}}$$)::JSON)->>'status',
+    'Failed',
+    'Check if gw_fct_scada_graph_build without object_2 returns status "Failed"'
+);
+
+SELECT is(
+    (gw_fct_scada_graph_build($${"client":{"device":4, "lang":"es_ES", "infoType":1, "epsg":25831},
+    "form":{}, "feature":{}, "data":{"parameters":{"object_1":1109, "object_2":1109}}}$$)::JSON)->>'status',
+    'Failed',
+    'Check if gw_fct_scada_graph_build with equal object_1/object_2 returns status "Failed"'
+);
+
+SELECT has_index(
+    'om_scada_graph',
+    'om_scada_graph_object_1_object_2_uidx',
+    'Table om_scada_graph should have unique index on object_1, object_2'
+);
+
+ALTER TABLE om_scada_graph DISABLE TRIGGER USER;
+
+INSERT INTO om_scada_graph (object_1, object_2, attrib, expl_1, expl_2)
+VALUES (-999, -998, '{"keep":"first"}', 1, 1);
+
+ALTER TABLE om_scada_graph ENABLE TRIGGER USER;
+
+SELECT is(
+    (gw_fct_scada_graph_build($${"client":{"device":4, "lang":"es_ES", "infoType":1, "epsg":25831},
+    "form":{}, "feature":{}, "data":{"parameters":{"object_1":-999, "object_2":-998}}}$$)::JSON)->>'status',
+    'Failed',
+    'Check if gw_fct_scada_graph_build rejects duplicate object_1/object_2'
+);
+
+SELECT throws_matching(
+    $$INSERT INTO om_scada_graph (object_1, object_2) VALUES (-999, -998)$$,
+    'already exists',
+    'Check if om_scada_graph trigger rejects duplicate object_1/object_2'
+);
+
+SELECT finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Type

Mark one:

- [ ] `fix`
- [ ] `feat`
- [X] `refactor`
- [ ] `chore`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`
- [ ] `contract`

## Summary

Speed up scada-graph Accept and block duplicate edges without changing the QGIS workflow.

- Reject exact `(object_1, object_2)` duplicates in the plugin, `gw_fct_scada_graph_build`, the BEFORE trigger, and unique index `om_scada_graph_object_1_object_2_uidx` (4.17.0 patch also deletes leftover dups). Reverse pair is still allowed.
- Recalc **this row only**: BEFORE trigger uses `pgr_dijkstra` on operative `arc` (geom + `attrib.arcs` + `is_scadamap`) instead of `gw_fct_getprofilevalues`; AFTER trigger sets `order_id = COALESCE(MIN(parent.order_id)+1, 1)` instead of full-graph `pgr_drivingdistance`.
- Accept pipeline: insert → trigger fills the new row → `gw_fct_scada_graph_export` writes `om_scada_graph_json`. Skip `gw_fct_scada_graph_check` here (toolbox check/fix unchanged). Return JSON is only `edgeId`, `object_1`, `object_2`.
- `gw_fct_scada_graph_check` `action=fix` is scoped to `edgeId` / the pair; quality/orphan scans skip on `fix`.
- QGIS: cache `om_graph`, show layer only if hidden, one `reloadData` + select + zoom; no extra `canvas.refresh()`.
- pgTAP: `dbmodel/test/ws/function/test_gw_fct_scada_graph_build.sql` (missing params, same node, unique index, build dup, trigger dup).

## Related issue

Block duplicate scada-graph rows; stop rebuilding the whole graph on each Accept.

## Scope

What this PR touches:

- [X] QGIS plugin (Python / UI)
- [X] dbmodel (SQL / patches)
- [ ] i18n
- [ ] CI / workflows
- [ ] docs
- [ ] contracts (JSON schemas / client-facing surfaces)

## Test plan

- [X] Manual check in QGIS (describe steps if non-obvious)
  - Open Scada graph, pick two connected nodes, Accept → one new `om_scada_graph` row (`MULTILINESTRING`, `attrib.arcs`, types/dma, `order_id`), layer zooms to the edge.
  - Accept the **same** pair again → info box “Scada graph edge already exists.” / build returns Failed; no second row.
  - Accept the reverse pair → allowed.
  - Same node in both fields → info box; missing node → info box.
  - Toolbox scada-graph check/fix still runs as before.
- [X] pgTAP / DB tests updated or green (if dbmodel touched)
  - Added `test_gw_fct_scada_graph_build.sql` (plan 5). Run with the rest of ws function tests.
- [ ] Lint / CI green on this PR
- [ ] Screenshots attached (if UI changed)

## Breaking / contract

- [ ] N/A
- [X] Client-facing surface changes (function/view/column shape)

If not N/A, follow the [contract-change issue template](./ISSUE_TEMPLATE/4-contract-change.md) and [dbmodel/MAINTENANCE.md](../dbmodel/MAINTENANCE.md):

- [ ] Linked contract / epic issue
- [X] Expand/migrate steps documented or done
- [X] Downgrade / deprecation handled if required

**Expand (additive, no contract issue):** unique index `om_scada_graph_object_1_object_2_uidx` on `(object_1, object_2)` in `updates/4/17/0/patch.sql`. Duplicate inserts now fail (`unique_violation` / Failed JSON).

**Return shape (`gw_fct_scada_graph_build`):** `body.data` is `{edgeId, object_1, object_2}` only. Full export JSON is **not** returned; it is still written to `om_scada_graph_json`. QGIS only ever used `edgeId`. Input JSON unchanged.

**Behavior (same columns, different values):** `order_id` is incremental on the new row (unchained edges stay `1`; old rows are not rewritten). Path is Dijkstra on `arc state=1`, not profile (`linksDistance:5`).

**Downgrade:** `DROP INDEX IF EXISTS om_scada_graph_object_1_object_2_uidx;` and restore previous build/check/export/trigger from git. No `DEPRECATED` tag (nothing removed from tables/views).