### PR TITLE
Fix/tableview alias sql

### DIFF
--- a/core/toolbars/plan/netscenario_manager_btn.py
+++ b/core/toolbars/plan/netscenario_manager_btn.py
@@ -660,7 +660,7 @@ class GwNetscenarioManagerButton(GwAction):
             if not is_manager:
                 # Get selected mapzone data
                 col_idx = tools_qt.get_col_index_by_col_name(tableview, f'{self.selected_netscenario_type.lower()}_id')
-                field_id = tableview.model().headerData(col_idx, Qt.Orientation.Horizontal)
+                field_id = tools_gw.get_model_column_name(tableview, col_idx)
                 mapzone_id = index.sibling(index.row(), col_idx).data()
 
                 if field_id == 'presszone_id':

--- a/core/toolbars/utilities/utilities_manager/mapzone_manager.py
+++ b/core/toolbars/utilities/utilities_manager/mapzone_manager.py
@@ -348,11 +348,18 @@ class GwMapzoneManager:
         return f've_{mapzone_type}'
 
     def _get_mapzone_id_column(self, tableview):
-        """Return (columnname, col_idx) for the mapzone PK (model column 0).
+        """Return (columnname, col_idx) for the mapzone PK.
 
+        Do not use model column 0: netscenario tables lead with netscenario_id (often hidden).
         headerData DisplayRole is the alias; get_model_column_name returns the SQL field.
         """
-        col_idx = 0
+        mapzone_type = self._get_mapzone_type(tableview)
+        col_name = f"{mapzone_type}_id" if mapzone_type else None
+        if col_name == 'valve_id':
+            col_name = 'node_id'
+        col_idx = tools_qt.get_col_index_by_col_name(tableview, col_name) if col_name else None
+        if col_idx in (None, False):
+            col_idx = 0
         return tools_gw.get_model_column_name(tableview, col_idx), col_idx
 
     def _load_main_tabs(self):

--- a/core/toolbars/utilities/utilities_manager/mapzone_manager.py
+++ b/core/toolbars/utilities/utilities_manager/mapzone_manager.py
@@ -347,6 +347,14 @@ class GwMapzoneManager:
             return f'plan_netscenario_{mapzone_type}'
         return f've_{mapzone_type}'
 
+    def _get_mapzone_id_column(self, tableview):
+        """Return (columnname, col_idx) for the mapzone PK (model column 0).
+
+        headerData DisplayRole is the alias; get_model_column_name returns the SQL field.
+        """
+        col_idx = 0
+        return tools_gw.get_model_column_name(tableview, col_idx), col_idx
+
     def _load_main_tabs(self):
         """Create dynamic manager tabs (table views) for project mapzone types."""
         if self.mapzone_mng_dlg.main_tab is None:
@@ -1718,11 +1726,11 @@ class GwMapzoneManager:
             return
 
         # Get selected mapzone data
+        field_id, col_idx = self._get_mapzone_id_column(tableview)
+        active_col = tools_qt.get_col_index_by_col_name(tableview, 'active')
         for index in selected_list:
-            mapzone_id = index.sibling(index.row(), 0).data()
-            active = index.sibling(index.row(), tools_qt.get_col_index_by_col_name(tableview, 'active')).data()
-            active = tools_os.set_boolean(active)
-            field_id = tableview.model().headerData(0, Qt.Orientation.Horizontal)
+            mapzone_id = index.sibling(index.row(), col_idx).data()
+            active = tools_os.set_boolean(index.sibling(index.row(), active_col).data())
 
             sql = f"UPDATE {view} SET active = {str(not active).lower()} WHERE {field_id}::text = '{mapzone_id}'"
             tools_db.execute_sql(sql)
@@ -1744,14 +1752,7 @@ class GwMapzoneManager:
         if not tablename:
             return
 
-        col_name = f"{mapzone_type}_id"
-        col_idx = tools_qt.get_col_index_by_col_name(tableview, col_name)
-        if col_idx in (None, False):
-            field_id = tableview.model().headerData(0, Qt.Orientation.Horizontal)
-        else:
-            field_id = tableview.model().headerData(col_idx, Qt.Orientation.Horizontal)
-        if field_id:
-            field_id = str(field_id).lower()
+        field_id, _ = self._get_mapzone_id_column(tableview)
 
         # Execute getinfofromid
         feature = f'"tableName":"{tablename}"'
@@ -1785,13 +1786,8 @@ class GwMapzoneManager:
 
         # Get selected mapzone data
         index = tableview.selectionModel().currentIndex()
-        col_name = f"{mapzone_type}_id"
-        if col_name == 'valve_id':
-            col_name = 'node_id'
-        col_idx = tools_qt.get_col_index_by_col_name(tableview, col_name)
-
+        field_id, col_idx = self._get_mapzone_id_column(tableview)
         mapzone_id = index.sibling(index.row(), col_idx).data()
-        field_id = tableview.model().headerData(col_idx, Qt.Orientation.Horizontal).lower()
 
         # Execute getinfofromid
         _id = f"{mapzone_id}"
@@ -1823,8 +1819,8 @@ class GwMapzoneManager:
             return
 
         # Get selected mapzone data
-        field_id = tableview.model().headerData(0, Qt.Orientation.Horizontal)
-        mapzone_ids = [index.sibling(index.row(), 0).data() for index in selected_list]
+        field_id, col_idx = self._get_mapzone_id_column(tableview)
+        mapzone_ids = [index.sibling(index.row(), col_idx).data() for index in selected_list]
 
         record_labels = []
         for index in selected_list:

--- a/core/utils/tools_gw.py
+++ b/core/utils/tools_gw.py
@@ -6095,11 +6095,15 @@ def set_tablemodel_config(dialog, widget, table_name, sort_order=Qt.SortOrder.As
                     header.moveSection(current_visual_index, i)
 
         columns_dict: Dict[str, str] = {}
+        header_meta: List[Tuple[int, Optional[str], str]] = []
         for row in rows:
             col_idx = col_indexes.get(row['columnname'])
             if col_idx is None:
                 continue
-            columns_dict[str(row['alias'] if row['alias'] else row['columnname'])] = str(row['columnname'])
+            columnname = str(row['columnname'])
+            alias = str(row['alias']) if row['alias'] else None
+            columns_dict[str(alias if alias else columnname)] = columnname
+            header_meta.append((col_idx, alias, columnname))
             if not row['visible']:
                 columns_to_delete.append(col_idx)
             else:
@@ -6117,13 +6121,12 @@ def set_tablemodel_config(dialog, widget, table_name, sort_order=Qt.SortOrder.As
                 if width is None:
                     width = 100
                 widget.setColumnWidth(col_idx, width)
-                if row['alias'] is not None:
-                    model.setHeaderData(col_idx, Qt.Orientation.Horizontal, row['alias'])
         widget.setProperty('columns', columns_dict)
-        # Set order
+        # Set order. select() can wipe custom headerData, so apply alias/columnname after it.
         if isinstance(model, QStandardItemModel) is False:
             model.setSort(0, sort_order)
             model.select()
+        _apply_model_header_names(model, header_meta)
         # Delete columns
         for column in columns_to_delete:
             if column is not None:
@@ -6152,6 +6155,48 @@ def _get_model_col_indexes(model) -> Dict[str, int]:
                 col_indexes.setdefault(str(header_text), i)
 
     return col_indexes
+
+
+def _apply_model_header_names(model, header_meta: List[Tuple[int, Optional[str], str]]) -> None:
+    """Set DisplayRole = alias and UserRole = columnname for each configured column."""
+    for col_idx, alias, columnname in header_meta:
+        model.setHeaderData(col_idx, Qt.Orientation.Horizontal, columnname, Qt.ItemDataRole.UserRole)
+        if alias is not None:
+            model.setHeaderData(col_idx, Qt.Orientation.Horizontal, alias)
+
+
+def get_model_column_name(widget, col_idx=0):
+    """Return the SQL columnname for tableview column @col_idx (not the header alias).
+
+    Preference order:
+      1. QSqlTableModel.record().fieldName(i)  — always the SQL field
+      2. headerData(..., UserRole)             — set by set_tablemodel_config
+      3. widget.property('columns')[alias]     — {alias: columnname}
+    headerData(..., DisplayRole) is the label ('Dma id') and must not be used in SQL.
+    """
+    if widget is None:
+        return None
+    model = widget.model()
+    if model is None:
+        return None
+
+    try:
+        name = model.record().fieldName(col_idx)
+        if name:
+            return name
+    except (AttributeError, IndexError):
+        pass
+
+    name = model.headerData(col_idx, Qt.Orientation.Horizontal, Qt.ItemDataRole.UserRole)
+    if name:
+        return str(name)
+
+    columns_dict = widget.property("columns") or {}
+    header = model.headerData(col_idx, Qt.Orientation.Horizontal)
+    if header is None:
+        return None
+    header = str(header)
+    return columns_dict.get(header, header)
 
 
 def add_icon(widget, icon, folder="dialogs"):


### PR DESCRIPTION
## Type

Mark one:

- [x] `fix`
- [ ] `feat`
- [ ] `refactor`
- [ ] `chore`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`
- [ ] `contract`

## Summary

`set_tablemodel_config` paints `headerData` with the config alias (`Dma id`). Mapzone/netscenario CRUD used that string in SQL → `syntax error at or near "id"`.

- Add `tools_gw.get_model_column_name()` (`record().fieldName` / header UserRole / `columns` dict)
- Mapzone manager: toggle/create/update/delete use columnname, not alias
- Netscenario manager: same for mapzone toggle (`AND dma_id = …`)

## Related issue

Closes #

## Scope

What this PR touches:

- [x] QGIS plugin (Python / UI)
- [ ] dbmodel (SQL / patches)
- [ ] i18n
- [ ] CI / workflows
- [ ] docs
- [ ] contracts (JSON schemas / client-facing surfaces)

## Test plan

- [ ] Manual check in QGIS (describe steps if non-obvious)
  - Mapzone manager: toggle active, create, update, delete on DMA (and another type). SQL must use `dma_id`, never `Dma id`
  - Netscenario manager: open a netscenario → DMA tab → toggle active. `WHERE netscenario_id = N AND dma_id = …`
- [ ] pgTAP / DB tests updated or green (if dbmodel touched)
- [ ] Lint / CI green on this PR
- [ ] Screenshots attached (if UI changed)

## Breaking / contract

- [x] N/A
- [ ] Client-facing surface changes (function/view/column shape)

If not N/A, follow the [contract-change issue template](./ISSUE_TEMPLATE/4-contract-change.md) and [dbmodel/MAINTENANCE.md](../dbmodel/MAINTENANCE.md):

- [ ] Linked contract / epic issue
- [ ] Expand/migrate steps documented or done
- [ ] Downgrade / deprecation handled if required